### PR TITLE
API improvement: Operators as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Automation rules allow your app's users to created automated workflows when even
 
 To install the package, run `npm install automation-rules` in your terminal
 
-Add `import ar from "automation-rules"` in your code wherever you wish to use the library.
+Add `import arule from "automation-rules"` in your code wherever you wish to use the library.
 
 Rules are composed of four parts: Trigger, Conditions, Callback and Description.
 
@@ -36,32 +36,34 @@ type Order = { items: Item[]; subtotal: number; tax: number; total: number }
 Example:
 
 ```typescript
-ar.addParam("total")
+arule.addParam("total")
 ```
 
 <hr>
 
 ### Operators
 
-Operators are used to compare two pieces of datainformation. These are static and provided by the library. To access, add `.op.` to your `ar` variable. For convenience of rendering in your UI, these operators resolve to human-readable strings.
+Operators are used to compare two pieces of datainformation. These are static and provided by the library. To access, evaluate `arule.operators`. For convenience of rendering in your UI, these operators resolve to human-readable strings. TypeScript offers autocomplete in code.
 
 Example:
 
 ```typescript
-ar.op.equals //=> "equals"
-ar.op.doesNotEqual //=> "does not equal"
-ar.op.didEqual //=> "did equal"
-ar.op.didNotEqual //=> "did not equal"
-ar.op.doesInclude //=> "does include"
-ar.op.doesNotInclude //=> "does not include"
-ar.op.hasChanged //=> "has changed"
-ar.op.hasNotChanged //=> "has not changed"
-ar.op.isGreatherThan //=> "is greater than"
-ar.op.isGreatherThanOrEqualTo //=> "is greater than or equal to"
-ar.op.isLessThan //=> "is less than"
-ar.op.isLessThanOrEqualTo //=> "is less than or equal to"
-ar.op.isFalsy //=> "is falsy"
-ar.op.isTruthy //=> "is truthy"
+const operators = [
+  "equals",
+  "does not equal",
+  "did equal",
+  "did not equal",
+  "includes",
+  "does not include",
+  "has changed",
+  "has not changed",
+  "is greater than",
+  "is greater than or equal to",
+  "is less than",
+  "is less than or equal to",
+  "is falsy",
+  "is truthy",
+]
 ```
 
 <hr>
@@ -85,9 +87,9 @@ Example:
 ```typescript
 type Order = { items: Item[]; subtotal: number; tax: number; total: number }
 
-const condition = ar.condition<Order>(
+const condition = arule.condition<Order>(
   "total",
-  ar.op.isGreaterThanOrEqualTo,
+  "is greater than or equal to",
   100
 )
 ```
@@ -117,15 +119,15 @@ const triggers = {
   ORDER_SUBMITTED: "When an order is submitted",
 }
 
-const myCondition = ar.condition<Order>(
+const myCondition = arule.condition<Order>(
   "total",
-  ar.op.isGreaterThanOrEqualTo,
+  "is greater than or equal to",
   100
 )
 
 const myCallback = (order: Order) => alert(`Order of ${order.total} submitted!`)
 
-const rule = ar.rule<Order>(
+const rule = arule.rule<Order>(
   triggers.ORDER_SUBMITTED,
   [myCondition],
   myCallback,
@@ -209,15 +211,15 @@ This method will return an array of all currently active rules.
 Example:
 
 ```typescript
-ar.getRules()
+arule.getRules()
 /*=> [
   { trigger: "When thing happens", 
-    conditions: [ar.condition("key", ar.op.equals, "value")],
+    conditions: [arule.condition("key", "equals", "value")],
     callback: (data) => { console.log(data) }
     description: "Log the data when thing happens"
   },
   { trigger: "When other thing happens", 
-    conditions: [ar.condition("key", ar.op.equals, "value")],
+    conditions: [arule.condition("key", "equals", "value")],
     callback: (data) => { alert(data.key) }
     description: "Alert the value of the key when other thing happens"
   }
@@ -238,10 +240,10 @@ This method will return an array of all currently active rules for a specific tr
 Example:
 
 ```typescript
-ar.getRulesByTrigger("when thing happens")
+arule.getRulesByTrigger("when thing happens")
 /*=> [
   { trigger: "When thing happens", 
-    conditions: [ar.condition("key", ar.op.equals, "value")],
+    conditions: [arule.condition("key", "equals", "value")],
     callback: (data) => { console.log(data) }
     description: "Log the data when thing happens"
   }

--- a/functions/condition.ts
+++ b/functions/condition.ts
@@ -24,7 +24,10 @@ export function isConditionMet<DataType>(
   data: DataType & { previous?: DataType }
 ) {
   type DataTypeKey = keyof DataType
-  const { operator, value } = condition
+  const {
+    operator,
+    value,
+  }: { operator: Operator; value: DataType[keyof DataType] } = condition
   const param = data[condition.param as DataTypeKey]
   const previousParam1 = data.previous
     ? data.previous[condition.param as DataTypeKey]
@@ -32,52 +35,52 @@ export function isConditionMet<DataType>(
   let result
 
   switch (operator) {
-    case operators.equals:
+    case "equals":
       result = param == value
       break
-    case operators.doesNotEqual:
+    case "does not equal":
       result = param != value
       break
-    case operators.didEqual:
+    case "did equal":
       console.log(previousParam1 + "==" + value)
 
       result = previousParam1 == value
       break
-    case operators.didNotEqual:
+    case "did not equal":
       result = previousParam1 != value
       break
-    case operators.doesInclude:
+    case "includes":
       if (typeof param === "string" || Array.isArray(param)) {
-        result = param.includes(value)
+        result = param.includes(value as (typeof param)[number])
       } else result = false
       break
-    case operators.doesNotInclude:
+    case "does not include":
       if (typeof param === "string" || Array.isArray(param)) {
-        result = !param.includes(value)
+        result = !param.includes(value as (typeof param)[number])
       } else result = false
       break
-    case operators.isGreatherThan:
+    case "is greater than":
       result = param > value
       break
-    case operators.isGreatherThanOrEqualTo:
+    case "is greater than or equal to":
       result = param >= value
       break
-    case operators.isLessThan:
+    case "is less than":
       result = param < value
       break
-    case operators.isGreatherThanOrEqualTo:
+    case "is less than or equal to":
       result = param <= value
       break
-    case operators.isFalsy:
+    case "is falsy":
       result = !param
       break
-    case operators.isTruthy:
+    case "is truthy":
       result = !!param
       break
-    case operators.hasChanged:
+    case "has changed":
       result = param !== previousParam1
       break
-    case operators.hasNotChanged:
+    case "has not changed":
       result = param === previousParam1
       break
     default:

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ import {
 import { condition } from "./functions/condition"
 import { setLogCallback, setLogging } from "./functions/logging"
 import { addParam, params } from "./functions/params"
-import * as op from "./operators"
+import * as operators from "./operators"
 import type { Trigger } from "./types"
 
 function executeRulesWithTrigger<DataType>(
@@ -26,7 +26,7 @@ export default {
   executeRulesWithTrigger,
   getRules,
   getRulesByTrigger,
-  op,
+  operators,
   params,
   rule,
   removeAllRules,

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ import {
 import { condition } from "./functions/condition"
 import { setLogCallback, setLogging } from "./functions/logging"
 import { addParam, params } from "./functions/params"
-import * as operators from "./operators"
+import { operators } from "./operators"
 import type { Trigger } from "./types"
 
 function executeRulesWithTrigger<DataType>(

--- a/operators.ts
+++ b/operators.ts
@@ -1,14 +1,16 @@
-export const equals = "equals"
-export const doesNotEqual = "does not equal"
-export const didEqual = "did equal"
-export const didNotEqual = "did not equal"
-export const doesInclude = "does include"
-export const doesNotInclude = "does not include"
-export const hasChanged = "has changed"
-export const hasNotChanged = "has not changed"
-export const isGreatherThan = "is greater than"
-export const isGreatherThanOrEqualTo = "is greater than or equal to"
-export const isLessThan = "is less than"
-export const isLessThanOrEqualTo = "is less than or equal to"
-export const isFalsy = "is falsy"
-export const isTruthy = "is truthy"
+export default [
+  "equals",
+  "does not equal",
+  "did equal",
+  "did not equal",
+  "does include",
+  "does not include",
+  "has changed",
+  "has not changed",
+  "is greater than",
+  "is greater than or equal to",
+  "is less than",
+  "is less than or equal to",
+  "is falsy",
+  "is truthy",
+]

--- a/operators.ts
+++ b/operators.ts
@@ -1,9 +1,9 @@
-export default [
+export const operators = [
   "equals",
   "does not equal",
   "did equal",
   "did not equal",
-  "does include",
+  "includes",
   "does not include",
   "has changed",
   "has not changed",
@@ -13,4 +13,4 @@ export default [
   "is less than or equal to",
   "is falsy",
   "is truthy",
-]
+] as const

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automation-rules",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Allow your app's users to created automated workflows when events occur and certain conditions are met.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test.spec.ts
+++ b/test.spec.ts
@@ -10,7 +10,7 @@ import {
   rules,
   setRuleId,
 } from "./functions/rule"
-import ar from "./index"
+import arule from "./index"
 import { logCallback, setLogCallback } from "./functions/logging"
 
 type DataType = { name: boolean }
@@ -18,15 +18,15 @@ type DataType = { name: boolean }
 describe("params", () => {
   describe("addParam", () => {
     it("adds a param", () => {
-      ar.addParam("derp")
-      expect(ar.params.includes("derp")).toBeTruthy()
+      arule.addParam("derp")
+      expect(arule.params.includes("derp")).toBeTruthy()
     })
   })
 })
 
 describe("operators", () => {
   it("contains all the correct operators", () => {
-    expect(ar.operators).toEqual([
+    expect(arule.operators).toEqual([
       "equals",
       "does not equal",
       "did equal",
@@ -48,7 +48,7 @@ describe("operators", () => {
 describe("conditions", () => {
   describe("condition", () => {
     it("returns a condition object", () => {
-      ar.addParam("name")
+      arule.addParam("name")
       const newCondition = condition<DataType>("name", "equals", true)
       expect(newCondition).toEqual({
         param: "name",
@@ -60,21 +60,21 @@ describe("conditions", () => {
 
   describe("isConditionMet", () => {
     it("returns true if condition is met", () => {
-      ar.addParam("name")
+      arule.addParam("name")
       const data = { name: true }
       const newCondition = condition<DataType>("name", "equals", true)
       expect(isConditionMet(newCondition, data)).toBeTruthy()
     })
 
     it("returns false if condition is not met", () => {
-      ar.addParam("name")
+      arule.addParam("name")
       const data = { name: false }
       const newCondition = condition<DataType>("name", "equals", true)
       expect(isConditionMet(newCondition, data)).toBeFalsy()
     })
 
     it("returns true if previous value matches condition", () => {
-      ar.addParam("name")
+      arule.addParam("name")
       const data = { name: true, previous: { name: false } }
       const newCondition = condition<DataType>("name", "did equal", false)
       expect(isConditionMet(newCondition, data)).toBeTruthy()
@@ -90,10 +90,15 @@ describe("rules", () => {
 
   describe("rule", () => {
     it("creates a new rule", () => {
-      ar.addParam("name")
+      arule.addParam("name")
       const callback = () => {}
       const newCondition = condition<DataType>("name", "equals", true)
-      const newRule = ar.rule("on test", [newCondition], callback, "test rule")
+      const newRule = arule.rule(
+        "on test",
+        [newCondition],
+        callback,
+        "test rule"
+      )
       expect(newRule).toEqual({
         callback,
         conditions: [newCondition],
@@ -105,20 +110,30 @@ describe("rules", () => {
 
   describe("executeAutomationRule", () => {
     it("calls the callback when conditions are met", () => {
-      ar.addParam("name")
+      arule.addParam("name")
       const callback = jest.fn()
       const newCondition = condition<DataType>("name", "equals", true)
-      const newRule = ar.rule("on test", [newCondition], callback, "test rule")
+      const newRule = arule.rule(
+        "on test",
+        [newCondition],
+        callback,
+        "test rule"
+      )
 
       executeAutomationRule(newRule, { name: true })
       expect(callback).toHaveBeenCalled()
     })
 
     it("doesn't call the callback when conditions are not met", () => {
-      ar.addParam("name")
+      arule.addParam("name")
       const callback = jest.fn()
       const newCondition = condition<DataType>("name", "equals", true)
-      const newRule = ar.rule("on test", [newCondition], callback, "test rule")
+      const newRule = arule.rule(
+        "on test",
+        [newCondition],
+        callback,
+        "test rule"
+      )
 
       executeAutomationRule(newRule, { name: false })
       expect(callback).not.toHaveBeenCalled()
@@ -128,14 +143,24 @@ describe("rules", () => {
   describe("addRules", () => {
     it("adds the new rules to the rules array", () => {
       const newCondition = condition<DataType>("name", "equals", true)
-      const newRule = ar.rule("on test", [newCondition], () => {}, "test rule")
+      const newRule = arule.rule(
+        "on test",
+        [newCondition],
+        () => {},
+        "test rule"
+      )
       addRules(newRule)
       expect(rules[0].description).toBe("test rule")
     })
 
     it("adds an id to a new rule", () => {
       const newCondition = condition<DataType>("name", "equals", true)
-      const newRule = ar.rule("on test", [newCondition], () => {}, "test rule")
+      const newRule = arule.rule(
+        "on test",
+        [newCondition],
+        () => {},
+        "test rule"
+      )
       addRules(newRule)
       expect(rules[0].id).toBe(1)
     })
@@ -144,8 +169,8 @@ describe("rules", () => {
   describe("removeRuleById", () => {
     it("removes the rule with the specified id", () => {
       const newCondition = condition<DataType>("name", "equals", true)
-      const newRule = ar.rule("on test", [newCondition], () => {}, "rule 1")
-      const newRule2 = ar.rule("on test", [newCondition], () => {}, "rule 2")
+      const newRule = arule.rule("on test", [newCondition], () => {}, "rule 1")
+      const newRule2 = arule.rule("on test", [newCondition], () => {}, "rule 2")
       addRules(newRule, newRule2)
       removeRuleById(1)
       expect(rules.length).toBe(1)
@@ -156,7 +181,12 @@ describe("rules", () => {
   describe("removeAllRules", () => {
     it("removes all rules from the rules array", () => {
       const newCondition = condition<DataType>("name", "equals", true)
-      const newRule = ar.rule("on test", [newCondition], () => {}, "test rule")
+      const newRule = arule.rule(
+        "on test",
+        [newCondition],
+        () => {},
+        "test rule"
+      )
       addRules(newRule)
       removeAllRules()
       expect(rules.length).toBe(0)
@@ -166,9 +196,19 @@ describe("rules", () => {
   describe("getRules", () => {
     it("returns all rules", () => {
       const newCondition = condition<DataType>("name", "equals", true)
-      const newRule = ar.rule("on test", [newCondition], () => {}, "test rule")
-      const newRule2 = ar.rule("on test", [newCondition], () => {}, "test rule")
-      const newRule3 = ar.rule("derp", [newCondition], () => {}, "test rule")
+      const newRule = arule.rule(
+        "on test",
+        [newCondition],
+        () => {},
+        "test rule"
+      )
+      const newRule2 = arule.rule(
+        "on test",
+        [newCondition],
+        () => {},
+        "test rule"
+      )
+      const newRule3 = arule.rule("derp", [newCondition], () => {}, "test rule")
 
       const rules = [newRule, newRule2, newRule3]
       addRules(...rules)
@@ -183,9 +223,19 @@ describe("rules", () => {
   describe("getRulesByTrigger", () => {
     it("returns all rules of a specific trigger", () => {
       const newCondition = condition<DataType>("name", "equals", true)
-      const newRule = ar.rule("on test", [newCondition], () => {}, "test rule")
-      const newRule2 = ar.rule("on test", [newCondition], () => {}, "test rule")
-      const newRule3 = ar.rule("derp", [newCondition], () => {}, "test rule")
+      const newRule = arule.rule(
+        "on test",
+        [newCondition],
+        () => {},
+        "test rule"
+      )
+      const newRule2 = arule.rule(
+        "on test",
+        [newCondition],
+        () => {},
+        "test rule"
+      )
+      const newRule3 = arule.rule("derp", [newCondition], () => {}, "test rule")
 
       const rules = [newRule, newRule2, newRule3]
       addRules(...rules)
@@ -198,9 +248,14 @@ describe("rules", () => {
       const newCondition = condition<DataType>("name", "equals", true)
       const callback1 = jest.fn()
       const callback2 = jest.fn()
-      const newRule = ar.rule("on test", [newCondition], callback1, "test rule")
+      const newRule = arule.rule(
+        "on test",
+        [newCondition],
+        callback1,
+        "test rule"
+      )
 
-      const newRule2 = ar.rule(
+      const newRule2 = arule.rule(
         "on test",
         [newCondition],
         callback2,
@@ -218,9 +273,14 @@ describe("rules", () => {
       const newCondition = condition<DataType>("name", "equals", true)
       const callback1 = jest.fn()
       const callback2 = jest.fn()
-      const newRule = ar.rule("on test", [newCondition], callback1, "test rule")
+      const newRule = arule.rule(
+        "on test",
+        [newCondition],
+        callback1,
+        "test rule"
+      )
 
-      const newRule2 = ar.rule(
+      const newRule2 = arule.rule(
         "on test",
         [newCondition],
         callback2,
@@ -228,7 +288,7 @@ describe("rules", () => {
       )
 
       addRules(newRule, newRule2)
-      ar.executeRulesWithTrigger("on test", { name: true })
+      arule.executeRulesWithTrigger("on test", { name: true })
 
       expect(callback1).toHaveBeenCalled()
       expect(callback2).toHaveBeenCalled()
@@ -245,12 +305,12 @@ describe("logging", () => {
 
   it("calls the logging callback with data", () => {
     const dummyLoggingCallback = jest.fn()
-    ar.setLogging({ onSuccess: true })
+    arule.setLogging({ onSuccess: true })
     setLogCallback(dummyLoggingCallback)
-    ar.addParam("name")
+    arule.addParam("name")
     const callback = jest.fn()
     const newCondition = condition<DataType>("name", "equals", true)
-    const newRule = ar.rule("on test", [newCondition], callback, "test rule")
+    const newRule = arule.rule("on test", [newCondition], callback, "test rule")
 
     executeAutomationRule(newRule, { name: true })
     expect(dummyLoggingCallback).toHaveBeenCalledWith(

--- a/test.spec.ts
+++ b/test.spec.ts
@@ -1,5 +1,4 @@
 import { condition, isConditionMet } from "./functions/condition"
-import {} from "./functions/logging"
 import {
   addRules,
   executeAutomationRule,
@@ -27,20 +26,22 @@ describe("params", () => {
 
 describe("operators", () => {
   it("contains all the correct operators", () => {
-    expect(ar.op.didEqual).toEqual("did equal")
-    expect(ar.op.didNotEqual).toEqual("did not equal")
-    expect(ar.op.doesInclude).toEqual("does include")
-    expect(ar.op.doesNotEqual).toEqual("does not equal")
-    expect(ar.op.doesNotInclude).toEqual("does not include")
-    expect(ar.op.equals).toEqual("equals")
-    expect(ar.op.hasChanged).toEqual("has changed")
-    expect(ar.op.hasNotChanged).toEqual("has not changed")
-    expect(ar.op.isFalsy).toEqual("is falsy")
-    expect(ar.op.isGreatherThan).toEqual("is greater than")
-    expect(ar.op.isGreatherThanOrEqualTo).toEqual("is greater than or equal to")
-    expect(ar.op.isLessThan).toEqual("is less than")
-    expect(ar.op.isLessThanOrEqualTo).toEqual("is less than or equal to")
-    expect(ar.op.isTruthy).toEqual("is truthy")
+    expect(ar.operators).toEqual([
+      "equals",
+      "does not equal",
+      "did equal",
+      "did not equal",
+      "includes",
+      "does not include",
+      "has changed",
+      "has not changed",
+      "is greater than",
+      "is greater than or equal to",
+      "is less than",
+      "is less than or equal to",
+      "is falsy",
+      "is truthy",
+    ])
   })
 })
 
@@ -48,10 +49,10 @@ describe("conditions", () => {
   describe("condition", () => {
     it("returns a condition object", () => {
       ar.addParam("name")
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       expect(newCondition).toEqual({
         param: "name",
-        operator: ar.op.equals,
+        operator: "equals",
         value: true,
       })
     })
@@ -61,21 +62,21 @@ describe("conditions", () => {
     it("returns true if condition is met", () => {
       ar.addParam("name")
       const data = { name: true }
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       expect(isConditionMet(newCondition, data)).toBeTruthy()
     })
 
     it("returns false if condition is not met", () => {
       ar.addParam("name")
       const data = { name: false }
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       expect(isConditionMet(newCondition, data)).toBeFalsy()
     })
 
     it("returns true if previous value matches condition", () => {
       ar.addParam("name")
       const data = { name: true, previous: { name: false } }
-      const newCondition = condition<DataType>("name", ar.op.didEqual, false)
+      const newCondition = condition<DataType>("name", "did equal", false)
       expect(isConditionMet(newCondition, data)).toBeTruthy()
     })
   })
@@ -91,7 +92,7 @@ describe("rules", () => {
     it("creates a new rule", () => {
       ar.addParam("name")
       const callback = () => {}
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = ar.rule("on test", [newCondition], callback, "test rule")
       expect(newRule).toEqual({
         callback,
@@ -106,7 +107,7 @@ describe("rules", () => {
     it("calls the callback when conditions are met", () => {
       ar.addParam("name")
       const callback = jest.fn()
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = ar.rule("on test", [newCondition], callback, "test rule")
 
       executeAutomationRule(newRule, { name: true })
@@ -116,7 +117,7 @@ describe("rules", () => {
     it("doesn't call the callback when conditions are not met", () => {
       ar.addParam("name")
       const callback = jest.fn()
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = ar.rule("on test", [newCondition], callback, "test rule")
 
       executeAutomationRule(newRule, { name: false })
@@ -126,14 +127,14 @@ describe("rules", () => {
 
   describe("addRules", () => {
     it("adds the new rules to the rules array", () => {
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = ar.rule("on test", [newCondition], () => {}, "test rule")
       addRules(newRule)
       expect(rules[0].description).toBe("test rule")
     })
 
     it("adds an id to a new rule", () => {
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = ar.rule("on test", [newCondition], () => {}, "test rule")
       addRules(newRule)
       expect(rules[0].id).toBe(1)
@@ -142,7 +143,7 @@ describe("rules", () => {
 
   describe("removeRuleById", () => {
     it("removes the rule with the specified id", () => {
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = ar.rule("on test", [newCondition], () => {}, "rule 1")
       const newRule2 = ar.rule("on test", [newCondition], () => {}, "rule 2")
       addRules(newRule, newRule2)
@@ -154,7 +155,7 @@ describe("rules", () => {
 
   describe("removeAllRules", () => {
     it("removes all rules from the rules array", () => {
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = ar.rule("on test", [newCondition], () => {}, "test rule")
       addRules(newRule)
       removeAllRules()
@@ -164,7 +165,7 @@ describe("rules", () => {
 
   describe("getRules", () => {
     it("returns all rules", () => {
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = ar.rule("on test", [newCondition], () => {}, "test rule")
       const newRule2 = ar.rule("on test", [newCondition], () => {}, "test rule")
       const newRule3 = ar.rule("derp", [newCondition], () => {}, "test rule")
@@ -181,7 +182,7 @@ describe("rules", () => {
 
   describe("getRulesByTrigger", () => {
     it("returns all rules of a specific trigger", () => {
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = ar.rule("on test", [newCondition], () => {}, "test rule")
       const newRule2 = ar.rule("on test", [newCondition], () => {}, "test rule")
       const newRule3 = ar.rule("derp", [newCondition], () => {}, "test rule")
@@ -194,7 +195,7 @@ describe("rules", () => {
 
   describe("executeRules", () => {
     it("executes all of the provided rules", () => {
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const callback1 = jest.fn()
       const callback2 = jest.fn()
       const newRule = ar.rule("on test", [newCondition], callback1, "test rule")
@@ -214,7 +215,7 @@ describe("rules", () => {
 
   describe("executeRulesWithTrigger", () => {
     it("executes all rules with the provided trigger", () => {
-      const newCondition = condition<DataType>("name", ar.op.equals, true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const callback1 = jest.fn()
       const callback2 = jest.fn()
       const newRule = ar.rule("on test", [newCondition], callback1, "test rule")
@@ -248,7 +249,7 @@ describe("logging", () => {
     setLogCallback(dummyLoggingCallback)
     ar.addParam("name")
     const callback = jest.fn()
-    const newCondition = condition<DataType>("name", ar.op.equals, true)
+    const newCondition = condition<DataType>("name", "equals", true)
     const newRule = ar.rule("on test", [newCondition], callback, "test rule")
 
     executeAutomationRule(newRule, { name: true })

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,7 +1,6 @@
-import * as operators from "../operators"
+import { operators } from "../operators"
 
-type OperatorKey = keyof typeof operators
-export type Operator = (typeof operators)[OperatorKey]
+export type Operator = (typeof operators)[number]
 
 export type Trigger = string
 


### PR DESCRIPTION
Change operators to an array of strings. Using object keys makes it more difficult for implementation because 

1. You have to map over Object.keys()
2. End users select a string which means you have to evaluate strings anyways. 

Note: Auto-complete benefits are still provided by using type 
```typescript
type Operator = typeof operators[number]
```