### PR TITLE
rm need for passing in key to condition

### DIFF
--- a/functions/condition.ts
+++ b/functions/condition.ts
@@ -2,10 +2,10 @@ import * as operators from "../operators"
 import { callLogCallback, logOnFailure } from "./logging"
 import type { Condition, Operator, Rule } from "../types"
 
-export function condition<T extends object, U extends keyof T>(
-  param: U,
+export function condition<T extends object>(
+  param: keyof T,
   operator: Operator,
-  value: T[U]
+  value: T[keyof T]
 ) {
   return {
     operator,

--- a/test.spec.ts
+++ b/test.spec.ts
@@ -49,7 +49,7 @@ describe("conditions", () => {
   describe("condition", () => {
     it("returns a condition object", () => {
       arule.addParam("name")
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       expect(newCondition).toEqual({
         param: "name",
         operator: "equals",
@@ -62,25 +62,21 @@ describe("conditions", () => {
     it("returns true if condition is met", () => {
       arule.addParam("name")
       const data = { name: true }
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       expect(isConditionMet(newCondition, data)).toBeTruthy()
     })
 
     it("returns false if condition is not met", () => {
       arule.addParam("name")
       const data = { name: false }
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       expect(isConditionMet(newCondition, data)).toBeFalsy()
     })
 
     it("returns true if previous value matches condition", () => {
       arule.addParam("name")
       const data = { name: true, previous: { name: false } }
-      const newCondition = condition<DataType, "name">(
-        "name",
-        "did equal",
-        false
-      )
+      const newCondition = condition<DataType>("name", "did equal", false)
       expect(isConditionMet(newCondition, data)).toBeTruthy()
     })
   })
@@ -96,7 +92,7 @@ describe("rules", () => {
     it("creates a new rule", () => {
       arule.addParam("name")
       const callback = () => {}
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = arule.rule(
         "on test",
         [newCondition],
@@ -116,7 +112,7 @@ describe("rules", () => {
     it("calls the callback when conditions are met", () => {
       arule.addParam("name")
       const callback = jest.fn()
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = arule.rule(
         "on test",
         [newCondition],
@@ -131,7 +127,7 @@ describe("rules", () => {
     it("doesn't call the callback when conditions are not met", () => {
       arule.addParam("name")
       const callback = jest.fn()
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = arule.rule(
         "on test",
         [newCondition],
@@ -146,7 +142,7 @@ describe("rules", () => {
 
   describe("addRules", () => {
     it("adds the new rules to the rules array", () => {
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = arule.rule(
         "on test",
         [newCondition],
@@ -158,7 +154,7 @@ describe("rules", () => {
     })
 
     it("adds an id to a new rule", () => {
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = arule.rule(
         "on test",
         [newCondition],
@@ -172,7 +168,7 @@ describe("rules", () => {
 
   describe("removeRuleById", () => {
     it("removes the rule with the specified id", () => {
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = arule.rule("on test", [newCondition], () => {}, "rule 1")
       const newRule2 = arule.rule("on test", [newCondition], () => {}, "rule 2")
       addRules(newRule, newRule2)
@@ -184,7 +180,7 @@ describe("rules", () => {
 
   describe("removeAllRules", () => {
     it("removes all rules from the rules array", () => {
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = arule.rule(
         "on test",
         [newCondition],
@@ -199,7 +195,7 @@ describe("rules", () => {
 
   describe("getRules", () => {
     it("returns all rules", () => {
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = arule.rule(
         "on test",
         [newCondition],
@@ -226,7 +222,7 @@ describe("rules", () => {
 
   describe("getRulesByTrigger", () => {
     it("returns all rules of a specific trigger", () => {
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const newRule = arule.rule(
         "on test",
         [newCondition],
@@ -249,7 +245,7 @@ describe("rules", () => {
 
   describe("executeRules", () => {
     it("executes all of the provided rules", () => {
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const callback1 = jest.fn()
       const callback2 = jest.fn()
       const newRule = arule.rule(
@@ -274,7 +270,7 @@ describe("rules", () => {
 
   describe("executeRulesWithTrigger", () => {
     it("executes all rules with the provided trigger", () => {
-      const newCondition = condition<DataType, "name">("name", "equals", true)
+      const newCondition = condition<DataType>("name", "equals", true)
       const callback1 = jest.fn()
       const callback2 = jest.fn()
       const newRule = arule.rule(
@@ -313,7 +309,7 @@ describe("logging", () => {
     setLogCallback(dummyLoggingCallback)
     arule.addParam("name")
     const callback = jest.fn()
-    const newCondition = condition<DataType, "name">("name", "equals", true)
+    const newCondition = condition<DataType>("name", "equals", true)
     const newRule = arule.rule("on test", [newCondition], callback, "test rule")
 
     executeAutomationRule(newRule, { name: true })


### PR DESCRIPTION
There's no need to require passing in a key to the generic on the condition function. You can require `keyof T` for param and `T[keyof T]` for value as data types.