### PR TITLE
v.1.8.0 Smarter syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To install the package, run `npm install automation-rules` in your terminal
 
 Add `import arule from "automation-rules"` in your code wherever you wish to use the library. (Note: You can use whatever alias you'd like.)
 
-Rules are composed of four parts: Trigger, Conditions, Callback and Description. Below is documentation of each of these as well as additional functions.
+Rules are composed of three parts: Trigger, Conditions and Callbacks. Below is documentation of each of these as well as additional functions.
 
 Additionally, there is an open-source sample project available at: https://github.com/stephengladney/ar-example
 
@@ -17,10 +17,11 @@ Additionally, there is an open-source sample project available at: https://githu
 A `Trigger` is a string that describes a particular event in your app that you want to allow users to build an automation rule around. It's recommended to write these in a way that's easy for your users to understand.
 
 ```typescript
-const myTriggers = {
-  NEW_USER_CREATED: "When a new user is created",
-  ORDER_SUBMITTED: "When an order is submitted",
-}
+const myTriggers = [
+  "When a user is created",
+  "When a message is received",
+  "When an order is submitted",
+]
 ```
 
 ### Params
@@ -243,31 +244,6 @@ This function will convert a JSON string retrieved from your database back to a 
 
 ### Additional functions
 
-#### getRules ()
-
-This method will return an array of all currently active rules.
-
-Example:
-
-```typescript
-arule.getRules()
-/*=> [
-  { trigger: "When thing happens", 
-    conditions: [arule.condition("key", "equals", "value")],
-    callback: (data) => { console.log(data) }
-    description: "Log the data when thing happens"
-  },
-  { trigger: "When other thing happens", 
-    conditions: [arule.condition("key", "equals", "value")],
-    callback: (data) => { alert(data.key) }
-    description: "Alert the value of the key when other thing happens"
-  }
-]
-*/
-```
-
-<hr>
-
 #### getRulesByTrigger ()
 
 ```typescript
@@ -279,10 +255,11 @@ This method will return an array of all currently active rules for a specific tr
 Example:
 
 ```typescript
-arule.getRulesByTrigger("when thing happens")
+arule.getRulesByTrigger("When a user is created")
 /*=> [
-  { trigger: "When thing happens", 
-    conditions: [arule.condition("key", "equals", "value")],
+  { id: 1
+    trigger: "When a user is created", 
+    conditions: {param: "age", operator: "is greater than or equal to", value: 21)],
     callback: (data) => { console.log(data) }
     description: "Log the data when thing happens"
   }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Additionally, there is an open-source sample project available at: https://githu
 
 ### Triggers
 
-A `Trigger` is a string that describes a particular event in your app that you want to allow users to build an automation rule around.
+A `Trigger` is a string that describes a particular event in your app that you want to allow users to build an automation rule around. It's recommended to write these in a way that's easy for your users to understand.
 
 ```typescript
 const myTriggers = {
@@ -25,7 +25,7 @@ const myTriggers = {
 
 ### Params
 
-The library works by reading object key/value pairs of data provided to evaluate whether or not conditions are met. Before creating rules, you must tell the library the names of the keys you wish to evaluate.
+The library works by reading object key/value pairs and evaluating whether or not specific conditions are met regarding the values. A `Param` is a key name (passed as a string) that you would like to evaluate the corresponding value of in automation rules.
 
 Example:
 
@@ -34,14 +34,14 @@ You want to evaluate the total price of an order. Your Order object has a key na
 ```typescript
 type Order = { items: Item[]; subtotal: number; tax: number; total: number }
 
-arule.addParam("total")
+arule.createParam("total")
 ```
 
 <hr>
 
 ### Operators
 
-Operators are used to compare two pieces of datainformation. These are static and provided by the library. To access, evaluate `arule.operators`. For convenience of rendering in your UI, these operators resolve to human-readable strings. TypeScript offers autocomplete in code.
+Operators are used to evaluate the value of something in an automation rules. These are static and provided by the library. To access, use `arule.operators`. For convenience of rendering in your UI, these operators resolve to human-readable strings. The library also includes an `Operator` type which you can use for taking advantage of autocomplete when writing code.
 
 Example:
 
@@ -71,7 +71,7 @@ const operators = [
 Conditions allow your users to verify that a specific scenario has been met. The `condition` function provides an easy way to get a typesafe condition.
 
 ```typescript
-function condition<T extends object>(
+function createCondition<T extends object>(
   param: keyof T,
   operator: Operator,
   value: T[keyof T]
@@ -85,7 +85,7 @@ Example:
 ```typescript
 type Order = { items: Item[]; subtotal: number; tax: number; total: number }
 
-const condition = arule.condition<Order>(
+const condition = arule.createCondition(
   "total",
   "is greater than or equal to",
   100
@@ -96,14 +96,15 @@ const condition = arule.condition<Order>(
 
 ### Rules
 
-Rules combine triggers, conditions with a callback function to execute when the conditions are met.
+Rules combine triggers, conditions with a callback function to execute when the conditions are met. You can optionally add a description or ID to the rule. Note: If no ID is passed, the library will assign an integer as the ID (auto-incremented).
 
 ```typescript
-function rule<DataType>(
+function createRule(
   trigger: Trigger,
   conditions: [Condition, ...Condition[]],
   callback: (data: DataType) => unknown,
-  description?: string
+  description?: string,
+  id?: number | string
 )
 ```
 
@@ -117,7 +118,7 @@ const triggers = {
   ORDER_SUBMITTED: "When an order is submitted",
 }
 
-const myCondition = arule.condition<Order>(
+const myCondition = arule.createCondition(
   "total",
   "is greater than or equal to",
   100
@@ -125,7 +126,7 @@ const myCondition = arule.condition<Order>(
 
 const myCallback = (order: Order) => alert(`Order of ${order.total} submitted!`)
 
-const rule = arule.rule<Order>(
+const rule = arule.createRule(
   triggers.ORDER_SUBMITTED,
   [myCondition],
   myCallback,
@@ -137,13 +138,39 @@ const rule = arule.rule<Order>(
 
 ### Callbacks
 
-This a function to invoke when a trigger occurs and all conditions are met.
+This a function that's call when a rule is invoked and all conditions are met. Rules are invoked by using the `executeRulesWithTrigger` function, which is covered below. This function takes in data to evaluate. This data is also passed to the callback function.
 
 ```typescript
 const exampleCallback = (data: DataType) => {
   /* do stuff */
 }
 ```
+
+Tip: You may want to use user-submitted values in your callbacks. To do this, create a function that takes in the user-submitted values and returns another function. Use this returned function for your automation rule's callback.
+
+Example:
+
+```typescript
+function getRuleCallback(value: string) {
+  return (data: DataType) => {
+    // some code that uses value
+    // ...and maybe data
+    }
+
+const myCallback = getRuleCallback(someUserSubmittedValue)
+```
+
+### Executing rules
+
+#### executeRulesWithTrigger
+
+Execute all rules with a particular trigger. Place this method in your code where that trigger occurs. For example, if your trigger is "When a user is created", add this to the code that creates a new user.
+
+```typescript
+function executeRulesWithTrigger<DataType>(trigger: Trigger, data: DataType)
+```
+
+<hr>
 
 ### Logging
 
@@ -181,27 +208,40 @@ type Callback = (
 function setLogCallback(callback: Callback)
 ```
 
+### Persisting rules
+
+Obviously, you will want the ability to persist automation rules created by your users in a database. The following section outlines how this is achieved.
+
+#### Function Dictionary
+
+Since functions themselves can't be stored to and retrieved from a database, we instead associate a name (string) with a function and store the name. A `FunctionDictionary` is an object that stores the names as keys and their functions as values. This is hard-coded and set once in your application's code.
+
+Example:
+
+```typescript
+arule.setFunctionDictionary({
+  sayhello: (data: { name: string }) => alert(`Hello ${data.name}!`),
+  saygoodbye: (data: { name: string }) => alert(`Goodbye ${data.name}!`),
+})
+```
+
+#### getJsonStringFromRule
+
+```typescript
+function getJsonStringFromRule(rule: Rule): string
+```
+
+Rules will be stored as JSON in your database. This is a function that returns a JSON string version of your rule that you can store in your database.
+
+#### getRuleFromJsonString
+
+```typescript
+function getRuleFromJsonString(json: string): Rule
+```
+
+This function will convert a JSON string retrieved from your database back to a `Rule` that can be executed in code.
+
 ### Additional functions
-
-#### addRules
-
-Add rule(s) to the current list of active rules.
-
-```typescript
-function addRules(...newRules: Rule[])
-```
-
-<hr>
-
-#### executeRulesWithTrigger
-
-Execute all rules with a particular trigger. Place this method in your code where that trigger occurs.
-
-```typescript
-function executeRulesWithTrigger<DataType>(trigger: Trigger, data: DataType)
-```
-
-<hr>
 
 #### getRules ()
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,18 @@ Additionally, there is an open-source sample project available at: https://githu
 
 ### Triggers
 
-A `Trigger` is a string that describes a particular event in your app that you want to allow users to build an automation rule around. It's recommended to write these in a way that's easy for your users to understand.
+A `Trigger` is a string that describes a particular event in your app that you want to allow users to build an automation rule around. To ensure type safety, hard-code these as a readonly object with keys of the types of the schemas you wish to evaluate and values of the events.
 
 ```typescript
-const myTriggers = [
-  "When a user is created",
-  "When a message is received",
-  "When an order is submitted",
-]
+const triggers = {
+  user: ["created", "deleted", "updated"],
+  team: ["created", "deleted", "updated", "suspened", "redeemed"],
+} as const
 ```
+
+You can then use these built-in functions to access type safe triggers in your code...
+
+####
 
 ### Params
 

--- a/functions/condition.ts
+++ b/functions/condition.ts
@@ -1,7 +1,7 @@
 import { callLogCallback, logOnFailure } from "./logging"
 import type { Condition, Operator, Rule } from "../types"
 
-export function condition<T extends object>(
+export function createCondition<T extends object>(
   param: keyof T,
   operator: Operator,
   value: T[keyof T]

--- a/functions/condition.ts
+++ b/functions/condition.ts
@@ -1,8 +1,8 @@
 import { callLogCallback, logOnFailure } from "./logging"
-import type { Condition, Operator, Rule } from "../types"
+import type { Condition, Operator, Param, Rule } from "../types"
 
 export function createCondition<T extends object>(
-  param: keyof T,
+  param: Param,
   operator: Operator,
   value: T[keyof T]
 ) {
@@ -27,9 +27,9 @@ export function isConditionMet<DataType>(
     operator,
     value,
   }: { operator: Operator; value: DataType[keyof DataType] } = condition
-  const param = data[condition.param as DataTypeKey]
+  const param = data[condition.param.key as DataTypeKey]
   const previousParam1 = data.previous
-    ? data.previous[condition.param as DataTypeKey]
+    ? data.previous[condition.param.key as DataTypeKey]
     : null
   let result
 

--- a/functions/condition.ts
+++ b/functions/condition.ts
@@ -1,10 +1,10 @@
-import { callLogCallback, logOnFailure } from "./logging"
+import { callLogCallback, logOnFailure } from "./log"
 import type { Condition, Operator, Param, Rule } from "../types"
 
-export function createCondition<T extends object>(
+export function createCondition(
   param: Param,
   operator: Operator,
-  value: T[keyof T]
+  value: unknown
 ) {
   return {
     operator,

--- a/functions/json.ts
+++ b/functions/json.ts
@@ -1,0 +1,38 @@
+import type { Rule } from "../types"
+
+export function getJsonStringFromRule(
+  rule: Rule,
+  functionDictionary: Record<string, Function>
+) {
+  return JSON.stringify({
+    id: rule.id,
+    trigger: rule.trigger,
+    conditions: JSON.stringify(rule.conditions),
+    callback: getKeyWhereValueIs(functionDictionary, rule.callback),
+    callbackDescription: rule.callbackDescription,
+    description: rule.description,
+  })
+}
+
+export function getRuleFromJsonString(
+  json: string,
+  functionDictionary: Record<string, Function>
+) {
+  const rule = JSON.parse(json)
+  return {
+    ...rule,
+    conditions: JSON.parse(rule.conditions),
+    callback:
+      functionDictionary[rule.callback as keyof typeof functionDictionary],
+  }
+}
+
+function getKeyWhereValueIs<T extends object>(
+  obj: T,
+  value: any
+): string | null {
+  for (let key in obj) {
+    if (obj[key] === value) return key
+  }
+  return null
+}

--- a/functions/log.ts
+++ b/functions/log.ts
@@ -21,7 +21,7 @@ type Callback = (
   failedCondition?: Condition
 ) => any
 
-export let logCallback: Callback = (params) => {}
+let logCallback: Callback = (params) => {}
 
 export function callLogCallback(
   rule: Rule,
@@ -34,4 +34,8 @@ export function callLogCallback(
 
 export function setLogCallback(callback: Callback) {
   logCallback = callback
+}
+
+export function getLogCallback() {
+  return logCallback
 }

--- a/functions/misc.ts
+++ b/functions/misc.ts
@@ -1,0 +1,3 @@
+export function isObjectInArray(obj: Object, arr: Object[]) {
+  return JSON.stringify(arr).includes(JSON.stringify(obj))
+}

--- a/functions/misc.ts
+++ b/functions/misc.ts
@@ -1,3 +1,0 @@
-export function isObjectInArray(obj: Object, arr: Object[]) {
-  return JSON.stringify(arr).includes(JSON.stringify(obj))
-}

--- a/functions/param.ts
+++ b/functions/param.ts
@@ -21,7 +21,7 @@ export function getParamKeysBySchema<
 export function getParamBySchemaAndKey<
   T extends Record<string, readonly string[]>,
   U extends keyof T
->(triggers: T, schema: U, key: T[U][number]) {
+>(params: T, schema: U, key: T[U][number]) {
   return {
     schema,
     key,

--- a/functions/param.ts
+++ b/functions/param.ts
@@ -1,20 +1,29 @@
-import type { Param } from "../types"
-import { isObjectInArray } from "./misc"
+import type { Param, ParamsMap } from "../types"
 
-export const params: Param[] = []
-
-export function createParams(
-  ...paramConstructors: { schema: string; keys: string[] }[]
-) {
-  paramConstructors.forEach(({ schema, keys }) => {
-    keys.forEach((key) => {
-      const newParam = { schema, key }
-      if (!isObjectInArray(newParam, params)) params.push(newParam as Param)
-    })
-  })
-  return params
+export function getParamSchemas(params: ParamsMap) {
+  return Object.keys(params)
 }
 
-export function getParamsBySchema(schema: string) {
-  return params.filter(({ schema: paramSchema }) => paramSchema === schema)
+export function getParamsBySchema<
+  T extends Record<string, readonly string[]>,
+  U extends keyof T
+>(params: T, schema: U) {
+  return params[schema].map((key) => ({ schema, key })) as Param[]
+}
+
+export function getParamKeysBySchema<
+  T extends Record<string, readonly string[]>,
+  K extends keyof T
+>(params: T, schema: K) {
+  return params[schema]
+}
+
+export function getParamBySchemaAndKey<
+  T extends Record<string, readonly string[]>,
+  U extends keyof T
+>(triggers: T, schema: U, key: T[U][number]) {
+  return {
+    schema,
+    key,
+  } as Param
 }

--- a/functions/param.ts
+++ b/functions/param.ts
@@ -1,0 +1,20 @@
+import type { Param } from "../types"
+import { isObjectInArray } from "./misc"
+
+export const params: Param[] = []
+
+export function createParams(
+  ...paramConstructors: { schema: string; keys: string[] }[]
+) {
+  paramConstructors.forEach(({ schema, keys }) => {
+    keys.forEach((key) => {
+      const newParam = { schema, key }
+      if (!isObjectInArray(newParam, params)) params.push(newParam as Param)
+    })
+  })
+  return params
+}
+
+export function getParamsBySchema(schema: string) {
+  return params.filter(({ schema: paramSchema }) => paramSchema === schema)
+}

--- a/functions/params.ts
+++ b/functions/params.ts
@@ -1,5 +1,5 @@
 export const params: string[] = []
 
-export function addParam<DataType>(name: keyof DataType) {
+export function createParam<DataType>(name: keyof DataType) {
   params.push(name as string)
 }

--- a/functions/params.ts
+++ b/functions/params.ts
@@ -1,6 +1,0 @@
-export const params: string[] = []
-
-export function createParam<DataType>(name: keyof DataType) {
-  params.push(name as string)
-  return name
-}

--- a/functions/params.ts
+++ b/functions/params.ts
@@ -2,4 +2,5 @@ export const params: string[] = []
 
 export function createParam<DataType>(name: keyof DataType) {
   params.push(name as string)
+  return name
 }

--- a/functions/rule.ts
+++ b/functions/rule.ts
@@ -1,6 +1,6 @@
 import { areAllConditionsMet } from "./condition"
 import { callLogCallback, logOnSuccess } from "./logging"
-import type { Condition, Rule, RuleJsonString, Trigger } from "../types"
+import type { Condition, Rule, Trigger } from "../types"
 
 type FunctionDictionary = { [key: string]: Function }
 

--- a/functions/rule.ts
+++ b/functions/rule.ts
@@ -1,8 +1,6 @@
 import { areAllConditionsMet } from "./condition"
-import { callLogCallback, logOnSuccess } from "./logging"
+import { callLogCallback, logOnSuccess } from "./log"
 import type { Condition, Rule, Trigger } from "../types"
-
-type FunctionDictionary = { [key: string]: Function }
 
 export let rules: Rule[] = []
 export let ruleId = 1
@@ -49,37 +47,8 @@ export function executeAutomationRule<DataType>(
   }
 }
 
-export function getRules() {
+export function getAllRules() {
   return rules
-}
-
-export function setFunctionDictionary(dictionary: FunctionDictionary) {
-  functionDictionary = dictionary
-}
-
-export function getFunctionDictionary(): FunctionDictionary {
-  return functionDictionary
-}
-
-export function getJsonStringFromRule(rule: Rule) {
-  return JSON.stringify({
-    id: rule.id,
-    trigger: rule.trigger,
-    conditions: JSON.stringify(rule.conditions),
-    callback: getKeyWhereValueIs(functionDictionary, rule.callback),
-    callbackDescription: rule.callbackDescription,
-    description: rule.description,
-  })
-}
-
-export function getRuleFromJsonString(json: string) {
-  const rule = JSON.parse(json)
-  return {
-    ...rule,
-    conditions: JSON.parse(rule.conditions),
-    callback:
-      functionDictionary[rule.callback as keyof typeof functionDictionary],
-  }
 }
 
 export function getRulesByTrigger(trigger: Trigger) {
@@ -100,14 +69,4 @@ export function removeAllRules() {
 
 export function setRuleId(n: number) {
   ruleId = n
-}
-
-function getKeyWhereValueIs<T extends object>(
-  obj: T,
-  value: any
-): string | null {
-  for (let key in obj) {
-    if (obj[key] === value) return key
-  }
-  return null
 }

--- a/functions/rule.ts
+++ b/functions/rule.ts
@@ -72,19 +72,6 @@ export function getJsonStringFromRule(rule: Rule) {
   })
 }
 
-// export function getJsonStringFromRules() {
-//   return JSON.stringify(
-//     rules.map((rule) => ({
-//       id: rule.id,
-//       trigger: rule.trigger,
-//       conditions: JSON.stringify(rule.conditions),
-//       callback: getKeyWhereValueIs(functionDictionary, rule.callback),
-//       callbackDescription: rule.callbackDescription,
-//       description: rule.description,
-//     }))
-//   )
-// }
-
 export function getRuleFromJsonString(json: string) {
   const rule = JSON.parse(json)
   return {
@@ -94,19 +81,6 @@ export function getRuleFromJsonString(json: string) {
       functionDictionary[rule.callback as keyof typeof functionDictionary],
   }
 }
-
-// export function getRulesFromJsonString(jsonString: string) {
-//   const rulesArray = JSON.parse(jsonString)
-//   const newRulesArray = rulesArray.map((rule: RuleJsonString) => {
-//     return {
-//       ...rule,
-//       conditions: JSON.parse(rule.conditions),
-//       callback:
-//         functionDictionary[rule.callback as keyof typeof functionDictionary],
-//     }
-//   })
-//   return newRulesArray as Rule[]
-// }
 
 export function getRulesByTrigger(trigger: Trigger) {
   return rules.filter((rule) => rule.trigger === trigger)

--- a/functions/trigger.ts
+++ b/functions/trigger.ts
@@ -1,21 +1,29 @@
-import { isObjectInArray } from "./misc"
-import type { Trigger } from "../types"
+import type { Trigger, TriggersMap } from "../types"
 
-export const triggers: Trigger[] = []
-
-export function createTriggers(
-  ...triggerConstructors: { schema: string; events: string[] }[]
-) {
-  triggerConstructors.forEach(({ schema, events: newEvents }) => {
-    newEvents.forEach((event) => {
-      const newTrigger = { schema, event }
-      if (!isObjectInArray(newTrigger, triggers))
-        triggers.push(newTrigger as Trigger)
-    })
-  })
-  return triggers
+export function getTriggerSchemas(triggers: TriggersMap) {
+  return Object.keys(triggers)
 }
 
-export function getTriggersBySchema(schema: string) {
-  return triggers.filter(({ schema: paramSchema }) => paramSchema === schema)
+export function getTriggersBySchema<
+  T extends Record<string, readonly string[]>,
+  K extends keyof T
+>(triggers: T, schema: K) {
+  return triggers[schema].map((event) => ({ schema, event })) as Trigger[]
+}
+
+export function getTriggerEventsBySchema<
+  T extends Record<string, readonly string[]>,
+  K extends keyof T
+>(triggers: T, schema: K) {
+  return triggers[schema]
+}
+
+export function getTriggerBySchemaAndEvent<
+  T extends Record<string, readonly string[]>,
+  U extends keyof T
+>(triggers: T, schema: U, event: T[U][number]) {
+  return {
+    schema,
+    event,
+  } as Trigger
 }

--- a/functions/trigger.ts
+++ b/functions/trigger.ts
@@ -1,0 +1,21 @@
+import { isObjectInArray } from "./misc"
+import type { Trigger } from "../types"
+
+export const triggers: Trigger[] = []
+
+export function createTriggers(
+  ...triggerConstructors: { schema: string; events: string[] }[]
+) {
+  triggerConstructors.forEach(({ schema, events: newEvents }) => {
+    newEvents.forEach((event) => {
+      const newTrigger = { schema, event }
+      if (!isObjectInArray(newTrigger, triggers))
+        triggers.push(newTrigger as Trigger)
+    })
+  })
+  return triggers
+}
+
+export function getTriggersBySchema(schema: string) {
+  return triggers.filter(({ schema: paramSchema }) => paramSchema === schema)
+}

--- a/index.ts
+++ b/index.ts
@@ -1,19 +1,27 @@
 import {
+  getTriggerBySchemaAndEvent,
+  getTriggerEventsBySchema,
+  getTriggerSchemas,
+  getTriggersBySchema,
+} from "./functions/trigger"
+import {
+  getParamBySchemaAndKey,
+  getParamKeysBySchema,
+  getParamsBySchema,
+  getParamSchemas,
+} from "./functions/param"
+import { operators } from "./operators"
+import { createCondition } from "./functions/condition"
+import {
   createRule,
   executeRules,
-  getFunctionDictionary,
-  getJsonStringFromRule,
-  getRuleFromJsonString,
-  getRules,
+  getAllRules,
   getRulesByTrigger,
-  setFunctionDictionary,
 } from "./functions/rule"
-import { createCondition } from "./functions/condition"
-import { setLogCallback, setLogging } from "./functions/logging"
-import { createParams, getParamsBySchema } from "./functions/param"
-import { getTriggersBySchema, createTriggers } from "./functions/trigger"
-import { operators } from "./operators"
-import type { Condition, Operator, Rule, Trigger } from "./types"
+import { getLogCallback, setLogCallback, setLogging } from "./functions/log"
+import { getJsonStringFromRule, getRuleFromJsonString } from "./functions/json"
+
+import type { Condition, Operator, Rule, SafeTrigger, Trigger } from "./types"
 
 function executeRulesWithTrigger<DataType>(
   trigger: Trigger,
@@ -22,23 +30,38 @@ function executeRulesWithTrigger<DataType>(
   executeRules(getRulesByTrigger(trigger), data)
 }
 
-export type { Condition, Operator, Rule }
+export type { Condition, Operator, Rule, Trigger }
 
 export default {
-  createCondition,
-  createParams,
-  createRule,
-  createTriggers,
-  executeRulesWithTrigger,
-  getFunctionDictionary,
-  getJsonStringFromRule,
-  getParamsBySchema,
-  getRuleFromJsonString,
-  getRules,
-  getRulesByTrigger,
-  getTriggersBySchema,
+  conditions: {
+    create: createCondition,
+  },
+  json: {
+    getJsonStringFromRule,
+    getRuleFromJsonString,
+  },
+  log: {
+    getLogCallback,
+    setLogCallback,
+    setLogging,
+  },
   operators,
-  setFunctionDictionary,
-  setLogCallback,
-  setLogging,
+  params: {
+    getAllBySchema: getParamsBySchema,
+    getBySchemaAndKey: getParamBySchemaAndKey,
+    keys: { getAllBySchema: getParamKeysBySchema },
+    schemas: { getAll: getParamSchemas },
+  },
+  rules: {
+    create: createRule,
+    executeAllByTrigger: executeRulesWithTrigger,
+    getAll: getAllRules,
+    getAllByTrigger: getRulesByTrigger,
+  },
+  triggers: {
+    events: { getAllBySchema: getTriggerEventsBySchema },
+    schemas: { getAll: getTriggerSchemas },
+    getAllBySchema: getTriggersBySchema,
+    getBySchemaAndEvent: getTriggerBySchemaAndEvent,
+  },
 }

--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,7 @@ import {
 import { getLogCallback, setLogCallback, setLogging } from "./functions/log"
 import { getJsonStringFromRule, getRuleFromJsonString } from "./functions/json"
 
-import type { Condition, Operator, Rule, SafeTrigger, Trigger } from "./types"
+import type { Condition, Operator, Rule, Trigger } from "./types"
 
 function executeRulesWithTrigger<DataType>(
   trigger: Trigger,

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,8 @@ import {
 } from "./functions/rule"
 import { createCondition } from "./functions/condition"
 import { setLogCallback, setLogging } from "./functions/logging"
-import { createParam, params } from "./functions/params"
+import { createParams, getParamsBySchema } from "./functions/param"
+import { getTriggersBySchema, createTriggers } from "./functions/trigger"
 import { operators } from "./operators"
 import type { Condition, Operator, Rule, Trigger } from "./types"
 
@@ -21,20 +22,22 @@ function executeRulesWithTrigger<DataType>(
   executeRules(getRulesByTrigger(trigger), data)
 }
 
-export type { Condition, Operator, Rule, Trigger }
+export type { Condition, Operator, Rule }
 
 export default {
   createCondition,
-  createParam,
+  createParams,
   createRule,
+  createTriggers,
   executeRulesWithTrigger,
   getFunctionDictionary,
   getJsonStringFromRule,
+  getParamsBySchema,
   getRuleFromJsonString,
   getRules,
   getRulesByTrigger,
+  getTriggersBySchema,
   operators,
-  params,
   setFunctionDictionary,
   setLogCallback,
   setLogging,

--- a/index.ts
+++ b/index.ts
@@ -1,19 +1,16 @@
 import {
-  addRule,
+  createRule,
   executeRules,
   getFunctionDictionary,
-  getJsonStringFromRules,
+  getJsonStringFromRule,
+  getRuleFromJsonString,
   getRules,
-  getRulesFromJsonString,
   getRulesByTrigger,
-  removeAllRules,
-  removeRuleById,
-  rule,
   setFunctionDictionary,
 } from "./functions/rule"
-import { condition } from "./functions/condition"
+import { createCondition } from "./functions/condition"
 import { setLogCallback, setLogging } from "./functions/logging"
-import { addParam, params } from "./functions/params"
+import { createParam, params } from "./functions/params"
 import { operators } from "./operators"
 import type { Condition, Operator, Rule, Trigger } from "./types"
 
@@ -27,20 +24,17 @@ function executeRulesWithTrigger<DataType>(
 export type { Condition, Operator, Rule, Trigger }
 
 export default {
-  addParam,
-  addRule,
-  condition,
+  createCondition,
+  createParam,
+  createRule,
   executeRulesWithTrigger,
   getFunctionDictionary,
-  getJsonStringFromRules,
+  getJsonStringFromRule,
+  getRuleFromJsonString,
   getRules,
-  getRulesFromJsonString,
   getRulesByTrigger,
   operators,
   params,
-  rule,
-  removeRuleById,
-  removeAllRules,
   setFunctionDictionary,
   setLogCallback,
   setLogging,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "automation-rules",
-  "version": "1.6.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "automation-rules",
-      "version": "1.6.0",
+      "version": "1.7.1",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^29.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "automation-rules",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "automation-rules",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^29.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automation-rules",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Allow your app's users to created automated workflows when events occur and certain conditions are met.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test.spec.ts
+++ b/test.spec.ts
@@ -108,14 +108,14 @@ describe("rules", () => {
     it("creates a new rule", () => {
       const callback = () => {}
       const newCondition = createCondition<DataType>(newParam, "equals", true)
-      const createRule = arule.createRule(
+      const newRule = arule.createRule(
         newTrigger,
         [newCondition],
         callback,
         "test callback",
         "test rule"
       )
-      expect(createRule).toEqual({
+      expect(newRule).toEqual({
         id: 1,
         callback,
         callbackDescription: "test callback",
@@ -129,7 +129,7 @@ describe("rules", () => {
       it("calls the callback when conditions are met", () => {
         const callback = jest.fn()
         const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const createRule = arule.createRule(
+        const newRule = arule.createRule(
           newTrigger,
           [newCondition],
           callback,
@@ -141,7 +141,7 @@ describe("rules", () => {
       it("doesn't call the callback when conditions are not met", () => {
         const callback = jest.fn()
         const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const createRule = arule.createRule(
+        const newRule = arule.createRule(
           newTrigger,
           [newCondition],
           callback,
@@ -149,7 +149,7 @@ describe("rules", () => {
           "test rule"
         )
 
-        executeAutomationRule(createRule, { name: false })
+        executeAutomationRule(newRule, { name: false })
         expect(callback).not.toHaveBeenCalled()
       })
     })
@@ -157,7 +157,7 @@ describe("rules", () => {
     describe("addRules", () => {
       it("adds the new rules to the rules array", () => {
         const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const createRule = arule.createRule(
+        const newRule = arule.createRule(
           newTrigger,
           [newCondition],
           () => {},
@@ -169,7 +169,7 @@ describe("rules", () => {
 
       it("adds an id to a new rule", () => {
         const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const createRule = arule.createRule(
+        const newRule = arule.createRule(
           newTrigger,
           [newCondition],
           () => {},
@@ -183,18 +183,8 @@ describe("rules", () => {
     describe("removeRuleById", () => {
       it("removes the rule with the specified id", () => {
         const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const createRule = arule.createRule(
-          newTrigger,
-          [newCondition],
-          () => {},
-          "rule 1"
-        )
-        const createRule2 = arule.createRule(
-          newTrigger,
-          [newCondition],
-          () => {},
-          "rule 2"
-        )
+        arule.createRule(newTrigger, [newCondition], () => {}, "rule 1")
+        arule.createRule(newTrigger, [newCondition], () => {}, "rule 2")
         removeRuleById(1)
         expect(rules.length).toBe(1)
         expect(rules[0].id).toBe(2)
@@ -204,7 +194,7 @@ describe("rules", () => {
     describe("removeAllRules", () => {
       it("removes all rules from the rules array", () => {
         const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const createRule = arule.createRule(
+        arule.createRule(
           newTrigger,
           [newCondition],
           () => {},
@@ -219,21 +209,21 @@ describe("rules", () => {
     describe("getRules", () => {
       it("returns all rules", () => {
         const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const createRule = arule.createRule(
+        const newRule = arule.createRule(
           newTrigger,
           [newCondition],
           () => {},
           "test callback",
           "test rule"
         )
-        const createRule2 = arule.createRule(
+        const newRule2 = arule.createRule(
           newTrigger,
           [newCondition],
           () => {},
           "test callback",
           "test rule"
         )
-        const createRule3 = arule.createRule(
+        const newRule3 = arule.createRule(
           newTrigger,
           [newCondition],
           () => {},
@@ -241,9 +231,9 @@ describe("rules", () => {
         )
 
         expect(getRules()).toEqual([
-          { ...createRule, id: 1 },
-          { ...createRule2, id: 2 },
-          { ...createRule3, id: 3 },
+          { ...newRule, id: 1 },
+          { ...newRule2, id: 2 },
+          { ...newRule3, id: 3 },
         ])
       })
     })
@@ -251,30 +241,28 @@ describe("rules", () => {
     describe("getRulesByTrigger", () => {
       it("returns all rules of a specific trigger", () => {
         const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const createRule = arule.createRule(
+        arule.createRule(
           { schema: "person", event: "derp" },
           [newCondition],
           () => {},
           "test callback",
           "test rule"
         )
-        const createRule2 = arule.createRule(
+        arule.createRule(
           { schema: "person", event: "derp2" },
           [newCondition],
           () => {},
           "test callback",
           "test rule"
         )
-        const createRule3 = arule.createRule(
+        const newRule3 = arule.createRule(
           newTrigger,
           [newCondition],
           () => {},
           "test rule"
         )
 
-        expect(getRulesByTrigger(newTrigger)).toEqual([
-          { ...createRule3, id: 3 },
-        ])
+        expect(getRulesByTrigger(newTrigger)).toEqual([{ ...newRule3, id: 3 }])
       })
     })
 
@@ -283,7 +271,7 @@ describe("rules", () => {
         const newCondition = createCondition<DataType>(newParam, "equals", true)
         const callback1 = jest.fn()
         const callback2 = jest.fn()
-        const createRule = arule.createRule(
+        const newRule = arule.createRule(
           newTrigger,
           [newCondition],
           callback1,
@@ -291,7 +279,7 @@ describe("rules", () => {
           "test rule"
         )
 
-        const createRule2 = arule.createRule(
+        const newRule2 = arule.createRule(
           newTrigger,
           [newCondition],
           callback2,
@@ -299,7 +287,7 @@ describe("rules", () => {
           "test rule"
         )
 
-        executeRules([createRule, createRule2], { name: true })
+        executeRules([newRule, newRule2], { name: true })
         expect(callback1).toHaveBeenCalled()
         expect(callback2).toHaveBeenCalled()
       })
@@ -310,7 +298,7 @@ describe("rules", () => {
         const newCondition = createCondition<DataType>(newParam, "equals", true)
         const callback1 = jest.fn()
         const callback2 = jest.fn()
-        const createRule = arule.createRule(
+        arule.createRule(
           newTrigger,
           [newCondition],
           callback1,
@@ -318,7 +306,7 @@ describe("rules", () => {
           "test rule"
         )
 
-        const createRule2 = arule.createRule(
+        arule.createRule(
           newTrigger,
           [newCondition],
           callback2,
@@ -383,7 +371,7 @@ describe("rules", () => {
       setLogCallback(dummyLoggingCallback)
       const callback = jest.fn()
       const newCondition = createCondition<DataType>(newParam, "equals", true)
-      const createRule = arule.createRule(
+      const newRule = arule.createRule(
         newTrigger,
         [newCondition],
         callback,
@@ -391,9 +379,9 @@ describe("rules", () => {
         "test rule"
       )
 
-      executeAutomationRule(createRule, { name: true })
+      executeAutomationRule(newRule, { name: true })
       expect(dummyLoggingCallback).toHaveBeenCalledWith(
-        createRule,
+        newRule,
         true,
         {
           name: true,

--- a/test.spec.ts
+++ b/test.spec.ts
@@ -13,14 +13,29 @@ import {
 } from "./functions/rule"
 import arule from "./index"
 import { logCallback, setLogCallback } from "./functions/logging"
+import { isObjectInArray } from "./functions/misc"
 
 type DataType = { name: boolean; age: number }
 
+const newTrigger = {
+  schema: "person",
+  event: "When a person is created",
+}
+const newParam = { schema: "person", key: "name" }
+
 describe("params", () => {
-  describe("createParam", () => {
+  describe("createParams", () => {
     it("adds a param", () => {
-      arule.createParam("derp")
-      expect(arule.params.includes("derp")).toBeTruthy()
+      arule.createParams({ schema: "person", keys: ["derp"] })
+      expect(
+        isObjectInArray(
+          {
+            schema: "person",
+            key: "derp",
+          },
+          arule.getParamsBySchema("person")
+        )
+      ).toBeTruthy()
     })
   })
 })
@@ -49,10 +64,9 @@ describe("operators", () => {
 describe("conditions", () => {
   describe("condition", () => {
     it("returns a condition object", () => {
-      arule.createParam("name")
-      const newCondition = createCondition<DataType>("name", "equals", true)
+      const newCondition = createCondition<DataType>(newParam, "equals", true)
       expect(newCondition).toEqual({
-        param: "name",
+        param: newParam,
         operator: "equals",
         value: true,
       })
@@ -61,23 +75,24 @@ describe("conditions", () => {
 
   describe("isConditionMet", () => {
     it("returns true if condition is met", () => {
-      arule.createParam("name")
       const data = { name: true }
-      const newCondition = createCondition<DataType>("name", "equals", true)
+      const newCondition = createCondition<DataType>(newParam, "equals", true)
       expect(isConditionMet(newCondition, data)).toBeTruthy()
     })
 
     it("returns false if condition is not met", () => {
-      arule.createParam("name")
       const data = { name: false }
-      const newCondition = createCondition<DataType>("name", "equals", true)
+      const newCondition = createCondition<DataType>(newParam, "equals", true)
       expect(isConditionMet(newCondition, data)).toBeFalsy()
     })
 
     it("returns true if previous value matches condition", () => {
-      arule.createParam("name")
       const data = { name: true, previous: { name: false } }
-      const newCondition = createCondition<DataType>("name", "did equal", false)
+      const newCondition = createCondition<DataType>(
+        newParam,
+        "did equal",
+        false
+      )
       expect(isConditionMet(newCondition, data)).toBeTruthy()
     })
   })
@@ -91,11 +106,10 @@ describe("rules", () => {
 
   describe("rule", () => {
     it("creates a new rule", () => {
-      arule.createParam("name")
       const callback = () => {}
-      const newCondition = createCondition<DataType>("name", "equals", true)
+      const newCondition = createCondition<DataType>(newParam, "equals", true)
       const createRule = arule.createRule(
-        "on test",
+        newTrigger,
         [newCondition],
         callback,
         "test callback",
@@ -107,18 +121,270 @@ describe("rules", () => {
         callbackDescription: "test callback",
         conditions: [newCondition],
         description: "test rule",
-        trigger: "on test",
+        trigger: newTrigger,
+      })
+    })
+
+    describe("executeAutomationRule", () => {
+      it("calls the callback when conditions are met", () => {
+        const callback = jest.fn()
+        const newCondition = createCondition<DataType>(newParam, "equals", true)
+        const createRule = arule.createRule(
+          newTrigger,
+          [newCondition],
+          callback,
+          "test callback",
+          "test rule"
+        )
+      })
+
+      it("doesn't call the callback when conditions are not met", () => {
+        const callback = jest.fn()
+        const newCondition = createCondition<DataType>(newParam, "equals", true)
+        const createRule = arule.createRule(
+          newTrigger,
+          [newCondition],
+          callback,
+          "test callback",
+          "test rule"
+        )
+
+        executeAutomationRule(createRule, { name: false })
+        expect(callback).not.toHaveBeenCalled()
+      })
+    })
+
+    describe("addRules", () => {
+      it("adds the new rules to the rules array", () => {
+        const newCondition = createCondition<DataType>(newParam, "equals", true)
+        const createRule = arule.createRule(
+          newTrigger,
+          [newCondition],
+          () => {},
+          "test callback",
+          "test rule"
+        )
+        expect(rules[0].description).toBe("test rule")
+      })
+
+      it("adds an id to a new rule", () => {
+        const newCondition = createCondition<DataType>(newParam, "equals", true)
+        const createRule = arule.createRule(
+          newTrigger,
+          [newCondition],
+          () => {},
+          "test callback",
+          "test rule"
+        )
+        expect(rules[0].id).toBe(1)
+      })
+    })
+
+    describe("removeRuleById", () => {
+      it("removes the rule with the specified id", () => {
+        const newCondition = createCondition<DataType>(newParam, "equals", true)
+        const createRule = arule.createRule(
+          newTrigger,
+          [newCondition],
+          () => {},
+          "rule 1"
+        )
+        const createRule2 = arule.createRule(
+          newTrigger,
+          [newCondition],
+          () => {},
+          "rule 2"
+        )
+        removeRuleById(1)
+        expect(rules.length).toBe(1)
+        expect(rules[0].id).toBe(2)
+      })
+    })
+
+    describe("removeAllRules", () => {
+      it("removes all rules from the rules array", () => {
+        const newCondition = createCondition<DataType>(newParam, "equals", true)
+        const createRule = arule.createRule(
+          newTrigger,
+          [newCondition],
+          () => {},
+          "test callback",
+          "test rule"
+        )
+        removeAllRules()
+        expect(rules.length).toBe(0)
+      })
+    })
+
+    describe("getRules", () => {
+      it("returns all rules", () => {
+        const newCondition = createCondition<DataType>(newParam, "equals", true)
+        const createRule = arule.createRule(
+          newTrigger,
+          [newCondition],
+          () => {},
+          "test callback",
+          "test rule"
+        )
+        const createRule2 = arule.createRule(
+          newTrigger,
+          [newCondition],
+          () => {},
+          "test callback",
+          "test rule"
+        )
+        const createRule3 = arule.createRule(
+          newTrigger,
+          [newCondition],
+          () => {},
+          "test rule"
+        )
+
+        expect(getRules()).toEqual([
+          { ...createRule, id: 1 },
+          { ...createRule2, id: 2 },
+          { ...createRule3, id: 3 },
+        ])
+      })
+    })
+
+    describe("getRulesByTrigger", () => {
+      it("returns all rules of a specific trigger", () => {
+        const newCondition = createCondition<DataType>(newParam, "equals", true)
+        const createRule = arule.createRule(
+          { schema: "person", event: "derp" },
+          [newCondition],
+          () => {},
+          "test callback",
+          "test rule"
+        )
+        const createRule2 = arule.createRule(
+          { schema: "person", event: "derp2" },
+          [newCondition],
+          () => {},
+          "test callback",
+          "test rule"
+        )
+        const createRule3 = arule.createRule(
+          newTrigger,
+          [newCondition],
+          () => {},
+          "test rule"
+        )
+
+        expect(getRulesByTrigger(newTrigger)).toEqual([
+          { ...createRule3, id: 3 },
+        ])
+      })
+    })
+
+    describe("executeRules", () => {
+      it("executes all of the provided rules", () => {
+        const newCondition = createCondition<DataType>(newParam, "equals", true)
+        const callback1 = jest.fn()
+        const callback2 = jest.fn()
+        const createRule = arule.createRule(
+          newTrigger,
+          [newCondition],
+          callback1,
+          "test callback",
+          "test rule"
+        )
+
+        const createRule2 = arule.createRule(
+          newTrigger,
+          [newCondition],
+          callback2,
+          "test callback",
+          "test rule"
+        )
+
+        executeRules([createRule, createRule2], { name: true })
+        expect(callback1).toHaveBeenCalled()
+        expect(callback2).toHaveBeenCalled()
+      })
+    })
+
+    describe("executeRulesWithTrigger", () => {
+      it("executes all rules with the provided trigger", () => {
+        const newCondition = createCondition<DataType>(newParam, "equals", true)
+        const callback1 = jest.fn()
+        const callback2 = jest.fn()
+        const createRule = arule.createRule(
+          newTrigger,
+          [newCondition],
+          callback1,
+          "test callback",
+          "test rule"
+        )
+
+        const createRule2 = arule.createRule(
+          newTrigger,
+          [newCondition],
+          callback2,
+          "test callback",
+          "test rule"
+        )
+
+        arule.executeRulesWithTrigger(newTrigger, { name: true })
+
+        expect(callback1).toHaveBeenCalled()
+        expect(callback2).toHaveBeenCalled()
+      })
+    })
+
+    describe("saving rules", () => {
+      it("converts both ways correctly", () => {
+        const newCondition = createCondition<DataType>(newParam, "equals", true)
+        const callback1 = jest.fn()
+        const callback2 = jest.fn()
+        const rule1 = arule.createRule(
+          newTrigger,
+          [newCondition],
+          callback1,
+          "test callback 1",
+          "test rule 1"
+        )
+
+        const rule2 = arule.createRule(
+          newTrigger,
+          [newCondition],
+          callback2,
+          "test callback 2",
+          "test rule 2"
+        )
+
+        arule.setFunctionDictionary({
+          "1stcallback": callback1,
+          "2ndcallback": callback2,
+        })
+        const before = arule.getRules()
+        const jsonString = getJsonStringFromRule(rule1)
+        const jsonString2 = getJsonStringFromRule(rule2)
+        const rule1Returned = getRuleFromJsonString(jsonString)
+        const rule2Returned = getRuleFromJsonString(jsonString2)
+        const after = [rule1Returned, rule2Returned]
+
+        expect(before).toEqual(after)
       })
     })
   })
 
-  describe("executeAutomationRule", () => {
-    it("calls the callback when conditions are met", () => {
-      arule.createParam("name")
+  describe("logging", () => {
+    it("lets the user set the logging callback", () => {
+      const dummyCallback = jest.fn()
+      setLogCallback(dummyCallback)
+      expect(logCallback).toBe(dummyCallback)
+    })
+
+    it("calls the logging callback with data", () => {
+      const dummyLoggingCallback = jest.fn()
+      arule.setLogging({ onSuccess: true })
+      setLogCallback(dummyLoggingCallback)
       const callback = jest.fn()
-      const newCondition = createCondition<DataType>("name", "equals", true)
+      const newCondition = createCondition<DataType>(newParam, "equals", true)
       const createRule = arule.createRule(
-        "on test",
+        newTrigger,
         [newCondition],
         callback,
         "test callback",
@@ -126,270 +392,14 @@ describe("rules", () => {
       )
 
       executeAutomationRule(createRule, { name: true })
-      expect(callback).toHaveBeenCalled()
+      expect(dummyLoggingCallback).toHaveBeenCalledWith(
+        createRule,
+        true,
+        {
+          name: true,
+        },
+        undefined
+      )
     })
-
-    it("doesn't call the callback when conditions are not met", () => {
-      arule.createParam("name")
-      const callback = jest.fn()
-      const newCondition = createCondition<DataType>("name", "equals", true)
-      const createRule = arule.createRule(
-        "on test",
-        [newCondition],
-        callback,
-        "test callback",
-        "test rule"
-      )
-
-      executeAutomationRule(createRule, { name: false })
-      expect(callback).not.toHaveBeenCalled()
-    })
-  })
-
-  describe("addRules", () => {
-    it("adds the new rules to the rules array", () => {
-      const newCondition = createCondition<DataType>("name", "equals", true)
-      const createRule = arule.createRule(
-        "on test",
-        [newCondition],
-        () => {},
-        "test callback",
-        "test rule"
-      )
-      expect(rules[0].description).toBe("test rule")
-    })
-
-    it("adds an id to a new rule", () => {
-      const newCondition = createCondition<DataType>("name", "equals", true)
-      const createRule = arule.createRule(
-        "on test",
-        [newCondition],
-        () => {},
-        "test callback",
-        "test rule"
-      )
-      expect(rules[0].id).toBe(1)
-    })
-  })
-
-  describe("removeRuleById", () => {
-    it("removes the rule with the specified id", () => {
-      const newCondition = createCondition<DataType>("name", "equals", true)
-      const createRule = arule.createRule(
-        "on test",
-        [newCondition],
-        () => {},
-        "rule 1"
-      )
-      const createRule2 = arule.createRule(
-        "on test",
-        [newCondition],
-        () => {},
-        "rule 2"
-      )
-      removeRuleById(1)
-      expect(rules.length).toBe(1)
-      expect(rules[0].id).toBe(2)
-    })
-  })
-
-  describe("removeAllRules", () => {
-    it("removes all rules from the rules array", () => {
-      const newCondition = createCondition<DataType>("name", "equals", true)
-      const createRule = arule.createRule(
-        "on test",
-        [newCondition],
-        () => {},
-        "test callback",
-        "test rule"
-      )
-      removeAllRules()
-      expect(rules.length).toBe(0)
-    })
-  })
-
-  describe("getRules", () => {
-    it("returns all rules", () => {
-      const newCondition = createCondition<DataType>("name", "equals", true)
-      const createRule = arule.createRule(
-        "on test",
-        [newCondition],
-        () => {},
-        "test callback",
-        "test rule"
-      )
-      const createRule2 = arule.createRule(
-        "on test",
-        [newCondition],
-        () => {},
-        "test callback",
-        "test rule"
-      )
-      const createRule3 = arule.createRule(
-        "derp",
-        [newCondition],
-        () => {},
-        "test rule"
-      )
-
-      expect(getRules()).toEqual([
-        { ...createRule, id: 1 },
-        { ...createRule2, id: 2 },
-        { ...createRule3, id: 3 },
-      ])
-    })
-  })
-
-  describe("getRulesByTrigger", () => {
-    it("returns all rules of a specific trigger", () => {
-      const newCondition = createCondition<DataType>("name", "equals", true)
-      const createRule = arule.createRule(
-        "on test",
-        [newCondition],
-        () => {},
-        "test callback",
-        "test rule"
-      )
-      const createRule2 = arule.createRule(
-        "on test",
-        [newCondition],
-        () => {},
-        "test callback",
-        "test rule"
-      )
-      const createRule3 = arule.createRule(
-        "derp",
-        [newCondition],
-        () => {},
-        "test rule"
-      )
-
-      expect(getRulesByTrigger("derp")).toEqual([{ ...createRule3, id: 3 }])
-    })
-  })
-
-  describe("executeRules", () => {
-    it("executes all of the provided rules", () => {
-      const newCondition = createCondition<DataType>("name", "equals", true)
-      const callback1 = jest.fn()
-      const callback2 = jest.fn()
-      const createRule = arule.createRule(
-        "on test",
-        [newCondition],
-        callback1,
-        "test callback",
-        "test rule"
-      )
-
-      const createRule2 = arule.createRule(
-        "on test",
-        [newCondition],
-        callback2,
-        "test callback",
-        "test rule"
-      )
-
-      executeRules([createRule, createRule2], { name: true })
-      expect(callback1).toHaveBeenCalled()
-      expect(callback2).toHaveBeenCalled()
-    })
-  })
-
-  describe("executeRulesWithTrigger", () => {
-    it("executes all rules with the provided trigger", () => {
-      const newCondition = createCondition<DataType>("name", "equals", true)
-      const callback1 = jest.fn()
-      const callback2 = jest.fn()
-      const createRule = arule.createRule(
-        "on test",
-        [newCondition],
-        callback1,
-        "test callback",
-        "test rule"
-      )
-
-      const createRule2 = arule.createRule(
-        "on test",
-        [newCondition],
-        callback2,
-        "test callback",
-        "test rule"
-      )
-
-      arule.executeRulesWithTrigger("on test", { name: true })
-
-      expect(callback1).toHaveBeenCalled()
-      expect(callback2).toHaveBeenCalled()
-    })
-  })
-
-  describe("saving rules", () => {
-    it("converts both ways correctly", () => {
-      const newCondition = createCondition<DataType>("name", "equals", true)
-      const callback1 = jest.fn()
-      const callback2 = jest.fn()
-      const rule1 = arule.createRule(
-        "on 1st test",
-        [newCondition],
-        callback1,
-        "test callback 1",
-        "test rule 1"
-      )
-
-      const rule2 = arule.createRule(
-        "on 2nd test",
-        [newCondition],
-        callback2,
-        "test callback 2",
-        "test rule 2"
-      )
-
-      arule.setFunctionDictionary({
-        "1stcallback": callback1,
-        "2ndcallback": callback2,
-      })
-      const before = arule.getRules()
-      const jsonString = getJsonStringFromRule(rule1)
-      const jsonString2 = getJsonStringFromRule(rule2)
-      const rule1Returned = getRuleFromJsonString(jsonString)
-      const rule2Returned = getRuleFromJsonString(jsonString2)
-      const after = [rule1Returned, rule2Returned]
-
-      expect(before).toEqual(after)
-    })
-  })
-})
-
-describe("logging", () => {
-  it("lets the user set the logging callback", () => {
-    const dummyCallback = jest.fn()
-    setLogCallback(dummyCallback)
-    expect(logCallback).toBe(dummyCallback)
-  })
-
-  it("calls the logging callback with data", () => {
-    const dummyLoggingCallback = jest.fn()
-    arule.setLogging({ onSuccess: true })
-    setLogCallback(dummyLoggingCallback)
-    arule.createParam("name")
-    const callback = jest.fn()
-    const newCondition = createCondition<DataType>("name", "equals", true)
-    const createRule = arule.createRule(
-      "on test",
-      [newCondition],
-      callback,
-      "test callback",
-      "test rule"
-    )
-
-    executeAutomationRule(createRule, { name: true })
-    expect(dummyLoggingCallback).toHaveBeenCalledWith(
-      createRule,
-      true,
-      {
-        name: true,
-      },
-      undefined
-    )
   })
 })

--- a/test.spec.ts
+++ b/test.spec.ts
@@ -2,47 +2,74 @@ import { createCondition, isConditionMet } from "./functions/condition"
 import {
   executeAutomationRule,
   executeRules,
-  getJsonStringFromRule,
-  getRules,
   getRulesByTrigger,
-  getRuleFromJsonString,
   removeAllRules,
   removeRuleById,
   rules,
   setRuleId,
 } from "./functions/rule"
-import arule from "./index"
-import { logCallback, setLogCallback } from "./functions/logging"
-import { isObjectInArray } from "./functions/misc"
+import automationrules from "./index"
 
 type DataType = { name: boolean; age: number }
 
-const newTrigger = {
-  schema: "person",
-  event: "When a person is created",
-}
-const newParam = { schema: "person", key: "name" }
+const triggers = {
+  person: ["When a person is created", "When a person is deleted"],
+} as const
+
+const params = { person: ["name", "age", "sex"] } as const
+
+const newParam = automationrules.params.getBySchemaAndKey(
+  params,
+  "person",
+  "name"
+)
+
+const newTrigger = automationrules.triggers.getBySchemaAndEvent(
+  triggers,
+  "person",
+  "When a person is created"
+)
 
 describe("params", () => {
-  describe("createParams", () => {
+  describe("getAllBySchema", () => {
     it("adds a param", () => {
-      arule.createParams({ schema: "person", keys: ["derp"] })
+      expect(automationrules.params.getAllBySchema(params, "person")).toEqual([
+        { schema: "person", key: "name" },
+        { schema: "person", key: "age" },
+        { schema: "person", key: "sex" },
+      ])
+    })
+  })
+
+  describe("getKeysBySchema", () => {
+    it("returns the correct keys", () => {
       expect(
-        isObjectInArray(
-          {
-            schema: "person",
-            key: "derp",
-          },
-          arule.getParamsBySchema("person")
-        )
-      ).toBeTruthy()
+        automationrules.params.keys.getAllBySchema(params, "person")
+      ).toEqual(["name", "age", "sex"])
+    })
+  })
+
+  describe("getBySchemaAndKey", () => {
+    it("returns the correct param", () => {
+      expect(
+        automationrules.params.getBySchemaAndKey(params, "person", "name")
+      ).toEqual({
+        schema: "person",
+        key: "name",
+      })
+    })
+  })
+
+  describe("getKeysBySchema", () => {
+    it("return", () => {
+      expect(automationrules.params.schemas.getAll(params)).toEqual(["person"])
     })
   })
 })
 
 describe("operators", () => {
   it("contains all the correct operators", () => {
-    expect(arule.operators).toEqual([
+    expect(automationrules.operators).toEqual([
       "equals",
       "does not equal",
       "did equal",
@@ -64,7 +91,7 @@ describe("operators", () => {
 describe("conditions", () => {
   describe("condition", () => {
     it("returns a condition object", () => {
-      const newCondition = createCondition<DataType>(newParam, "equals", true)
+      const newCondition = createCondition(newParam, "equals", true)
       expect(newCondition).toEqual({
         param: newParam,
         operator: "equals",
@@ -76,23 +103,19 @@ describe("conditions", () => {
   describe("isConditionMet", () => {
     it("returns true if condition is met", () => {
       const data = { name: true }
-      const newCondition = createCondition<DataType>(newParam, "equals", true)
+      const newCondition = createCondition(newParam, "equals", true)
       expect(isConditionMet(newCondition, data)).toBeTruthy()
     })
 
     it("returns false if condition is not met", () => {
       const data = { name: false }
-      const newCondition = createCondition<DataType>(newParam, "equals", true)
+      const newCondition = createCondition(newParam, "equals", true)
       expect(isConditionMet(newCondition, data)).toBeFalsy()
     })
 
     it("returns true if previous value matches condition", () => {
       const data = { name: true, previous: { name: false } }
-      const newCondition = createCondition<DataType>(
-        newParam,
-        "did equal",
-        false
-      )
+      const newCondition = createCondition(newParam, "did equal", false)
       expect(isConditionMet(newCondition, data)).toBeTruthy()
     })
   })
@@ -107,8 +130,8 @@ describe("rules", () => {
   describe("rule", () => {
     it("creates a new rule", () => {
       const callback = () => {}
-      const newCondition = createCondition<DataType>(newParam, "equals", true)
-      const newRule = arule.createRule(
+      const newCondition = createCondition(newParam, "equals", true)
+      const newRule = automationrules.rules.create(
         newTrigger,
         [newCondition],
         callback,
@@ -124,254 +147,25 @@ describe("rules", () => {
         trigger: newTrigger,
       })
     })
-
-    describe("executeAutomationRule", () => {
-      it("calls the callback when conditions are met", () => {
-        const callback = jest.fn()
-        const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const newRule = arule.createRule(
-          newTrigger,
-          [newCondition],
-          callback,
-          "test callback",
-          "test rule"
-        )
-      })
-
-      it("doesn't call the callback when conditions are not met", () => {
-        const callback = jest.fn()
-        const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const newRule = arule.createRule(
-          newTrigger,
-          [newCondition],
-          callback,
-          "test callback",
-          "test rule"
-        )
-
-        executeAutomationRule(newRule, { name: false })
-        expect(callback).not.toHaveBeenCalled()
-      })
-    })
-
-    describe("addRules", () => {
-      it("adds the new rules to the rules array", () => {
-        const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const newRule = arule.createRule(
-          newTrigger,
-          [newCondition],
-          () => {},
-          "test callback",
-          "test rule"
-        )
-        expect(rules[0].description).toBe("test rule")
-      })
-
-      it("adds an id to a new rule", () => {
-        const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const newRule = arule.createRule(
-          newTrigger,
-          [newCondition],
-          () => {},
-          "test callback",
-          "test rule"
-        )
-        expect(rules[0].id).toBe(1)
-      })
-    })
-
-    describe("removeRuleById", () => {
-      it("removes the rule with the specified id", () => {
-        const newCondition = createCondition<DataType>(newParam, "equals", true)
-        arule.createRule(newTrigger, [newCondition], () => {}, "rule 1")
-        arule.createRule(newTrigger, [newCondition], () => {}, "rule 2")
-        removeRuleById(1)
-        expect(rules.length).toBe(1)
-        expect(rules[0].id).toBe(2)
-      })
-    })
-
-    describe("removeAllRules", () => {
-      it("removes all rules from the rules array", () => {
-        const newCondition = createCondition<DataType>(newParam, "equals", true)
-        arule.createRule(
-          newTrigger,
-          [newCondition],
-          () => {},
-          "test callback",
-          "test rule"
-        )
-        removeAllRules()
-        expect(rules.length).toBe(0)
-      })
-    })
-
-    describe("getRules", () => {
-      it("returns all rules", () => {
-        const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const newRule = arule.createRule(
-          newTrigger,
-          [newCondition],
-          () => {},
-          "test callback",
-          "test rule"
-        )
-        const newRule2 = arule.createRule(
-          newTrigger,
-          [newCondition],
-          () => {},
-          "test callback",
-          "test rule"
-        )
-        const newRule3 = arule.createRule(
-          newTrigger,
-          [newCondition],
-          () => {},
-          "test rule"
-        )
-
-        expect(getRules()).toEqual([
-          { ...newRule, id: 1 },
-          { ...newRule2, id: 2 },
-          { ...newRule3, id: 3 },
-        ])
-      })
-    })
-
-    describe("getRulesByTrigger", () => {
-      it("returns all rules of a specific trigger", () => {
-        const newCondition = createCondition<DataType>(newParam, "equals", true)
-        arule.createRule(
-          { schema: "person", event: "derp" },
-          [newCondition],
-          () => {},
-          "test callback",
-          "test rule"
-        )
-        arule.createRule(
-          { schema: "person", event: "derp2" },
-          [newCondition],
-          () => {},
-          "test callback",
-          "test rule"
-        )
-        const newRule3 = arule.createRule(
-          newTrigger,
-          [newCondition],
-          () => {},
-          "test rule"
-        )
-
-        expect(getRulesByTrigger(newTrigger)).toEqual([{ ...newRule3, id: 3 }])
-      })
-    })
-
-    describe("executeRules", () => {
-      it("executes all of the provided rules", () => {
-        const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const callback1 = jest.fn()
-        const callback2 = jest.fn()
-        const newRule = arule.createRule(
-          newTrigger,
-          [newCondition],
-          callback1,
-          "test callback",
-          "test rule"
-        )
-
-        const newRule2 = arule.createRule(
-          newTrigger,
-          [newCondition],
-          callback2,
-          "test callback",
-          "test rule"
-        )
-
-        executeRules([newRule, newRule2], { name: true })
-        expect(callback1).toHaveBeenCalled()
-        expect(callback2).toHaveBeenCalled()
-      })
-    })
-
-    describe("executeRulesWithTrigger", () => {
-      it("executes all rules with the provided trigger", () => {
-        const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const callback1 = jest.fn()
-        const callback2 = jest.fn()
-        arule.createRule(
-          newTrigger,
-          [newCondition],
-          callback1,
-          "test callback",
-          "test rule"
-        )
-
-        arule.createRule(
-          newTrigger,
-          [newCondition],
-          callback2,
-          "test callback",
-          "test rule"
-        )
-
-        arule.executeRulesWithTrigger(newTrigger, { name: true })
-
-        expect(callback1).toHaveBeenCalled()
-        expect(callback2).toHaveBeenCalled()
-      })
-    })
-
-    describe("saving rules", () => {
-      it("converts both ways correctly", () => {
-        const newCondition = createCondition<DataType>(newParam, "equals", true)
-        const callback1 = jest.fn()
-        const callback2 = jest.fn()
-        const rule1 = arule.createRule(
-          newTrigger,
-          [newCondition],
-          callback1,
-          "test callback 1",
-          "test rule 1"
-        )
-
-        const rule2 = arule.createRule(
-          newTrigger,
-          [newCondition],
-          callback2,
-          "test callback 2",
-          "test rule 2"
-        )
-
-        arule.setFunctionDictionary({
-          "1stcallback": callback1,
-          "2ndcallback": callback2,
-        })
-        const before = arule.getRules()
-        const jsonString = getJsonStringFromRule(rule1)
-        const jsonString2 = getJsonStringFromRule(rule2)
-        const rule1Returned = getRuleFromJsonString(jsonString)
-        const rule2Returned = getRuleFromJsonString(jsonString2)
-        const after = [rule1Returned, rule2Returned]
-
-        expect(before).toEqual(after)
-      })
-    })
   })
 
-  describe("logging", () => {
-    it("lets the user set the logging callback", () => {
-      const dummyCallback = jest.fn()
-      setLogCallback(dummyCallback)
-      expect(logCallback).toBe(dummyCallback)
+  describe("executeAutomationRule", () => {
+    it("calls the callback when conditions are met", () => {
+      const callback = jest.fn()
+      const newCondition = createCondition(newParam, "equals", true)
+      const newRule = automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        callback,
+        "test callback",
+        "test rule"
+      )
     })
 
-    it("calls the logging callback with data", () => {
-      const dummyLoggingCallback = jest.fn()
-      arule.setLogging({ onSuccess: true })
-      setLogCallback(dummyLoggingCallback)
+    it("doesn't call the callback when conditions are not met", () => {
       const callback = jest.fn()
-      const newCondition = createCondition<DataType>(newParam, "equals", true)
-      const newRule = arule.createRule(
+      const newCondition = createCondition(newParam, "equals", true)
+      const newRule = automationrules.rules.create(
         newTrigger,
         [newCondition],
         callback,
@@ -379,15 +173,282 @@ describe("rules", () => {
         "test rule"
       )
 
-      executeAutomationRule(newRule, { name: true })
-      expect(dummyLoggingCallback).toHaveBeenCalledWith(
-        newRule,
-        true,
-        {
-          name: true,
-        },
-        undefined
-      )
+      executeAutomationRule(newRule, { name: false })
+      expect(callback).not.toHaveBeenCalled()
     })
+  })
+
+  describe("addRules", () => {
+    it("adds the new rules to the rules array", () => {
+      const newCondition = createCondition(newParam, "equals", true)
+      const newRule = automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        () => {},
+        "test callback",
+        "test rule"
+      )
+      expect(rules[0].description).toBe("test rule")
+    })
+
+    it("adds an id to a new rule", () => {
+      const newCondition = createCondition(newParam, "equals", true)
+      const newRule = automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        () => {},
+        "test callback",
+        "test rule"
+      )
+      expect(rules[0].id).toBe(1)
+    })
+  })
+
+  describe("removeRuleById", () => {
+    it("removes the rule with the specified id", () => {
+      const newCondition = createCondition(newParam, "equals", true)
+      automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        () => {},
+        "rule 1"
+      )
+      automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        () => {},
+        "rule 2"
+      )
+      removeRuleById(1)
+      expect(rules.length).toBe(1)
+      expect(rules[0].id).toBe(2)
+    })
+  })
+
+  describe("removeAllRules", () => {
+    it("removes all rules from the rules array", () => {
+      const newCondition = createCondition(newParam, "equals", true)
+      automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        () => {},
+        "test callback",
+        "test rule"
+      )
+      removeAllRules()
+      expect(rules.length).toBe(0)
+    })
+  })
+
+  describe("getRules", () => {
+    it("returns all rules", () => {
+      const newCondition = createCondition(newParam, "equals", true)
+      const newRule = automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        () => {},
+        "test callback",
+        "test rule"
+      )
+      const newRule2 = automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        () => {},
+        "test callback",
+        "test rule"
+      )
+      const newRule3 = automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        () => {},
+        "test rule"
+      )
+
+      expect(automationrules.rules.getAll()).toEqual([
+        { ...newRule, id: 1 },
+        { ...newRule2, id: 2 },
+        { ...newRule3, id: 3 },
+      ])
+    })
+  })
+
+  describe("getRulesByTrigger", () => {
+    it("returns all rules of a specific trigger", () => {
+      const newCondition = createCondition(newParam, "equals", true)
+      automationrules.rules.create(
+        { schema: "person", event: "derp" },
+        [newCondition],
+        () => {},
+        "test callback",
+        "test rule"
+      )
+      automationrules.rules.create(
+        { schema: "person", event: "derp2" },
+        [newCondition],
+        () => {},
+        "test callback",
+        "test rule"
+      )
+      const newRule3 = automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        () => {},
+        "test rule"
+      )
+
+      expect(getRulesByTrigger(newTrigger)).toEqual([{ ...newRule3, id: 3 }])
+    })
+  })
+
+  describe("executeRules", () => {
+    it("executes all of the provided rules", () => {
+      const newCondition = automationrules.conditions.create(
+        newParam,
+        "equals",
+        true
+      )
+      const callback1 = jest.fn()
+      const callback2 = jest.fn()
+      const newRule = automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        callback1,
+        "test callback",
+        "test rule"
+      )
+
+      const newRule2 = automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        callback2,
+        "test callback",
+        "test rule"
+      )
+
+      executeRules([newRule, newRule2], { name: true })
+      expect(callback1).toHaveBeenCalled()
+      expect(callback2).toHaveBeenCalled()
+    })
+  })
+
+  describe("executeRulesWithTrigger", () => {
+    it("executes all rules with the provided trigger", () => {
+      const newCondition = automationrules.conditions.create(
+        newParam,
+        "equals",
+        true
+      )
+      const callback1 = jest.fn()
+      const callback2 = jest.fn()
+      automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        callback1,
+        "test callback",
+        "test rule"
+      )
+
+      automationrules.rules.create(
+        newTrigger,
+        [newCondition],
+        callback2,
+        "test callback",
+        "test rule"
+      )
+
+      automationrules.rules.executeAllByTrigger(newTrigger, { name: true })
+
+      expect(callback1).toHaveBeenCalled()
+      expect(callback2).toHaveBeenCalled()
+    })
+  })
+})
+
+describe("json", () => {
+  it("converts both ways correctly", () => {
+    const newCondition = automationrules.conditions.create(
+      newParam,
+      "equals",
+      true
+    )
+    const callback1 = jest.fn()
+    const callback2 = jest.fn()
+    const rule1 = automationrules.rules.create(
+      newTrigger,
+      [newCondition],
+      callback1,
+      "test callback 1",
+      "test rule 1"
+    )
+
+    const rule2 = automationrules.rules.create(
+      newTrigger,
+      [newCondition],
+      callback2,
+      "test callback 2",
+      "test rule 2"
+    )
+
+    const functionDictionary = {
+      "1stcallback": callback1,
+      "2ndcallback": callback2,
+    }
+    const before = automationrules.rules.getAll()
+    const jsonString = automationrules.json.getJsonStringFromRule(
+      rule1,
+      functionDictionary
+    )
+    const jsonString2 = automationrules.json.getJsonStringFromRule(
+      rule2,
+      functionDictionary
+    )
+    const rule1Returned = automationrules.json.getRuleFromJsonString(
+      jsonString,
+      functionDictionary
+    )
+    const rule2Returned = automationrules.json.getRuleFromJsonString(
+      jsonString2,
+      functionDictionary
+    )
+    const after = [rule1Returned, rule2Returned]
+
+    expect(before).toEqual(after)
+  })
+})
+
+describe("logging", () => {
+  it("lets the user set the logging callback", () => {
+    const dummyCallback = jest.fn()
+    automationrules.log.setLogCallback(dummyCallback)
+    expect(automationrules.log.getLogCallback()).toBe(dummyCallback)
+  })
+
+  it("calls the logging callback with data", () => {
+    const dummyLoggingCallback = jest.fn()
+    automationrules.log.setLogging({ onSuccess: true })
+    automationrules.log.setLogCallback(dummyLoggingCallback)
+    const callback = jest.fn()
+    const newCondition = automationrules.conditions.create(
+      newParam,
+      "equals",
+      true
+    )
+    const newRule = automationrules.rules.create(
+      newTrigger,
+      [newCondition],
+      callback,
+      "test callback",
+      "test rule"
+    )
+
+    executeAutomationRule(newRule, { name: true })
+    expect(dummyLoggingCallback).toHaveBeenCalledWith(
+      newRule,
+      true,
+      {
+        name: true,
+      },
+      undefined
+    )
   })
 })

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,12 +1,12 @@
 import { operators } from "../operators"
 
+export type Trigger = { schema: string; event: string }
+export type Param = { schema: string; key: string }
 export type Operator = (typeof operators)[number]
-
-export type Trigger = string
 
 export type Condition = {
   operator: Operator
-  param: string
+  param: Param
   value: any
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -18,12 +18,3 @@ export type Rule = {
   callbackDescription?: string
   description: string
 }
-
-export type RuleJsonString = {
-  id: string | number
-  trigger: string
-  conditions: string
-  callback: string
-  callbackDescription: string
-  description: string
-}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,7 +1,16 @@
 import { operators } from "../operators"
 
+export type TriggersMap = { readonly [key: string]: readonly string[] }
 export type Trigger = { schema: string; event: string }
+
+export type ParamsMap = { readonly [key: string]: readonly string[] }
 export type Param = { schema: string; key: string }
+
+export type SafeTrigger<
+  T extends Record<string, readonly string[]>,
+  U extends keyof T
+> = T[U][number]
+
 export type Operator = (typeof operators)[number]
 
 export type Condition = {


### PR DESCRIPTION
# Version 1.80

- Require that users hard-code triggers
- Require that users hard-code params
- Schematize main exports (i.e. `automationrules.params.__`, `automationrules.triggers.__`, etc.) to reduce autocomplete suggestions.

Requiring hard-coded triggers and params allows for type safety in code.